### PR TITLE
Add segment writer with lazy, mmap'd reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +675,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -1133,6 +1148,8 @@ dependencies = [
 name = "tachyon-index"
 version = "0.1.0"
 dependencies = [
+ "fst",
+ "memmap2",
  "roaring",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ docker run -p 8108:8108 ghcr.io/tachyon-search/tachyon:latest
 > **Status: alpha.** The API is stable enough to build against and every
 > feature below is tested end to end, but this has not run in production
 > anywhere. See [Known limitations](#known-limitations) before you rely on it —
-> in particular, **all data currently lives in memory**.
+> in particular, **queries get slower as a collection accumulates segments**,
+> since nothing merges them yet.
 
 ---
 
@@ -123,20 +124,24 @@ corpus**; see [Known limitations](#known-limitations).
 
 Read this before choosing Tachyon.
 
-**Everything is held in memory.** Writes are durable — they go to a write-ahead
-log and are replayed on startup — but the memtable is never flushed into an
-on-disk segment, so RAM use grows with the corpus and startup replays the whole
-log. At roughly **1.1 KiB per document**, 5M documents needs about 5 GiB, above
-the 2.5 GiB the design targets. The segment writer is the single most important
-next piece of work: the query engine already reads through a source abstraction
-that segments plug into, and the commit protocol (`state.json`, WAL generations,
-tombstone bitmaps) is built and tested around them.
+**Segment count is unbounded.** Writes are durable — they go to a write-ahead
+log and are replayed on startup — and once a memtable crosses
+`--max-memtable-docs`/`--max-memtable-bytes` it is flushed into an immutable,
+mmap'd on-disk segment: postings, columns, and document values are all read
+lazily and decoded only for what a query actually touches, which is what
+keeps memory bounded by how much of the corpus is hot rather than by corpus
+size. What isn't done yet is merging: a query runs over the memtable plus
+every committed segment with nothing folding them back together, so a
+long-lived collection accumulates segments and each one adds its own share of
+per-query overhead. Measured at the default 100k-document flush threshold:
+search p95 was ~9 ms at 100k documents (1 segment), ~88 ms at 1M (10
+segments), ~524 ms at 5M (50 segments). Tiered merges are the next piece of
+work here.
 
-**Broad queries scale linearly.** Every matching document is scored. At 1M
-documents a query matching 6% of the corpus costs ~68 ms at p95. Real catalogues
-are far more selective — and adding a filter already halves it — but the fix is
-block-max WAND early termination, which would let the executor skip documents
-that cannot reach the top-K.
+**Broad queries scale linearly.** Every matching document is scored. Real
+catalogues are far more selective than a broad query — and adding a filter
+already halves the cost — but the fix is block-max WAND early termination,
+which would let the executor skip documents that cannot reach the top-K.
 
 **Not yet built:** distributed clustering, replication, synonyms, stemming, stop
 words, highlighting, geo search, and nested documents. All are explicit
@@ -173,7 +178,7 @@ Needs Rust 1.85 or newer.
 
 ```bash
 cargo build --release        # binary at target/release/tachyon
-cargo test                   # 318 tests
+cargo test                   # 350 tests
 cargo clippy --all-targets
 ```
 
@@ -183,7 +188,7 @@ The workspace is layered so each crate depends only on the ones below it:
 tachyon-server   REST API, auth, analytics, metrics, the binary
 tachyon-engine   collection lifecycle, write path, recovery
 tachyon-query    parsing, planning, scoring, ranking
-tachyon-index    tokenizer, inverted index, columns, fuzzy matching
+tachyon-index    tokenizer, inverted index, columns, fuzzy matching, segments
 tachyon-storage  write-ahead log, on-disk layout, metadata
 tachyon-core     schema, values, documents, errors
 ```

--- a/crates/tachyon-bench/src/main.rs
+++ b/crates/tachyon-bench/src/main.rs
@@ -10,6 +10,8 @@
 
 mod corpus;
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use clap::Parser;
@@ -47,6 +49,20 @@ struct Args {
     /// Also benchmark filtered, sorted, and faceted searches.
     #[arg(long, default_value_t = true)]
     full: bool,
+
+    /// Also run a flush-under-load scenario: a low `--max-memtable-docs` so
+    /// segment flushes happen mid-run, with a background thread searching
+    /// continuously, to measure what a flush — which holds the write lock
+    /// for its full duration — costs concurrent readers. Off by default: the
+    /// scenario above stays flush-free on purpose, so its numbers remain a
+    /// stable baseline unaffected by the flush path's own performance.
+    #[arg(long)]
+    flush_scenario: bool,
+
+    /// Memtable document threshold for `--flush-scenario`, chosen well below
+    /// `--documents` so several flushes happen during one run.
+    #[arg(long, default_value_t = 5_000)]
+    flush_scenario_max_memtable_docs: usize,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -154,6 +170,100 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     let suggest = Measurement { latencies: suggest_latencies, total_hits: suggestions as u64 };
     report("Autocomplete", &suggest, 5.0);
+
+    if args.flush_scenario {
+        run_flush_scenario(&args)?;
+    }
+
+    Ok(())
+}
+
+/// Index the corpus into a collection whose memtable threshold is crossed
+/// repeatedly, while a background thread searches the whole time, and report
+/// search latency under that concurrent flush load. A separate collection and
+/// scenario from the one above — the goal here is to see flush's cost, not to
+/// fold it into (and skew) the flush-free baseline.
+fn run_flush_scenario(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
+    println!("Flush-under-load scenario");
+    println!("  documents               {}", args.documents);
+    println!("  max_memtable_docs       {}", args.flush_scenario_max_memtable_docs);
+    println!();
+
+    let dir = tempfile::tempdir()?;
+    let layout = Layout::new(dir.path());
+    layout.initialize()?;
+    let config = EngineConfig::new(dir.path())
+        .with_sync_policy(SyncPolicy::Interval(Duration::from_millis(200)))
+        .with_max_memtable_docs(args.flush_scenario_max_memtable_docs);
+
+    let collection = Arc::new(Collection::create(&layout, corpus::schema("products"), &config)?);
+
+    let mut rng = Rng::new(args.seed ^ 0x5eed);
+    let queries = corpus::queries(&mut rng, args.queries.max(200));
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let latencies = Arc::new(Mutex::new(Vec::<u64>::new()));
+    let total_hits = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+    let search_thread = {
+        let collection = Arc::clone(&collection);
+        let stop = Arc::clone(&stop);
+        let latencies = Arc::clone(&latencies);
+        let total_hits = Arc::clone(&total_hits);
+        let queries = queries.clone();
+        std::thread::spawn(move || {
+            let mut i = 0usize;
+            while !stop.load(Ordering::Relaxed) {
+                let q = &queries[i % queries.len()];
+                let started = Instant::now();
+                if let Ok(response) =
+                    collection.search(SearchParams { q: Some(q.clone()), ..Default::default() })
+                {
+                    total_hits.fetch_add(response.found as u64, Ordering::Relaxed);
+                }
+                latencies
+                    .lock()
+                    .expect("latencies mutex poisoned")
+                    .push(started.elapsed().as_micros() as u64);
+                i += 1;
+            }
+        })
+    };
+
+    let mut rng = Rng::new(args.seed);
+    let started = Instant::now();
+    let mut indexed = 0usize;
+    while indexed < args.documents {
+        let this_batch = args.batch_size.min(args.documents - indexed);
+        let batch: Vec<_> =
+            (0..this_batch).map(|i| corpus::document(&mut rng, indexed + i)).collect();
+        let report = collection.upsert_batch(batch)?;
+        if report.num_failed > 0 {
+            return Err(format!("{} documents failed to index", report.num_failed).into());
+        }
+        indexed += this_batch;
+    }
+    let index_elapsed = started.elapsed();
+
+    stop.store(true, Ordering::Relaxed);
+    search_thread.join().expect("search thread panicked");
+
+    let stats = collection.stats();
+    println!("Indexing (with flushes)");
+    println!("  elapsed                 {:.2}s", index_elapsed.as_secs_f64());
+    println!(
+        "  throughput              {:.0} docs/sec",
+        args.documents as f64 / index_elapsed.as_secs_f64()
+    );
+    println!("  segments produced       {}", stats.num_segments);
+    println!("  documents               {}", stats.num_documents);
+    println!();
+
+    let latencies =
+        Arc::try_unwrap(latencies).expect("search thread has joined").into_inner().unwrap();
+    let total_hits = total_hits.load(Ordering::Relaxed);
+    let measurement = Measurement { latencies, total_hits };
+    report("Search, concurrent with flushing", &measurement, 60.0);
 
     Ok(())
 }

--- a/crates/tachyon-engine/src/collection.rs
+++ b/crates/tachyon-engine/src/collection.rs
@@ -16,6 +16,8 @@
 //! order. Because doc ids are assigned sequentially from `state.next_doc_id`,
 //! replay reconstructs exactly the ids the crashed process had assigned.
 
+use std::sync::Arc;
+
 use parking_lot::RwLock;
 use roaring::RoaringBitmap;
 use serde::Serialize;
@@ -23,14 +25,29 @@ use serde_json::Value as Json;
 use utoipa::ToSchema;
 
 use tachyon_core::{CollectionSchema, DocId, Error, ParsedDocument, Result};
-use tachyon_index::MemTable;
+use tachyon_index::{encode, IndexSource, MemTable, SegmentFilePaths, SegmentReader};
 use tachyon_query::{
     compute_facets, execute, suggest, Hit, SearchContext, SearchParams, SearchRequest,
     SearchResponse, SuggestParams, SuggestRequest, SuggestResponse,
 };
-use tachyon_storage::{meta, wal, CollectionState, Layout, Wal, WalRecord, WalRecordRef};
+use tachyon_storage::layout::sync_dir;
+use tachyon_storage::{
+    meta, wal, write_atomic, CollectionState, Layout, SegmentRef, Wal, WalRecord, WalRecordRef,
+};
 
 use crate::config::EngineConfig;
+
+/// Path of every file one segment id is stored as, under this collection's
+/// `segments/` directory.
+fn segment_file_paths(layout: &Layout, name: &str, id: u64) -> SegmentFilePaths {
+    SegmentFilePaths {
+        terms: layout.segment_file(name, id, "terms"),
+        ids: layout.segment_file(name, id, "ids"),
+        post: layout.segment_file(name, id, "post"),
+        col: layout.segment_file(name, id, "col"),
+        doc: layout.segment_file(name, id, "doc"),
+    }
+}
 
 /// Per-document result of a batch write. A batch is not all-or-nothing: PRD
 /// §7.2 requires atomicity *per document*, so one malformed document does not
@@ -84,6 +101,10 @@ struct Inner {
     state: CollectionState,
     wal: Wal,
     memtable: MemTable,
+    /// Committed segments, oldest first. Consulted newest-first (`.rev()`)
+    /// after a memtable miss, since a later segment's version of an id, if
+    /// any, is the current one.
+    segments: Vec<Arc<SegmentReader>>,
     /// Tombstones for doc ids that live in committed segments. Memtable
     /// documents are deleted in place, so they never appear here.
     deleted: RoaringBitmap,
@@ -128,6 +149,14 @@ impl Collection {
             deleted.insert(*id);
         }
 
+        // Segments before replay: a replayed upsert or delete may reference a
+        // document whose only prior version already lives in one of them.
+        let mut segments = Vec::with_capacity(state.segments.len());
+        for seg_ref in &state.segments {
+            let paths = segment_file_paths(layout, name, seg_ref.id);
+            segments.push(Arc::new(SegmentReader::open(&paths, &schema)?));
+        }
+
         let mut memtable = MemTable::new(state.next_doc_id, &schema);
         let mut next_seq = state.next_seq;
 
@@ -153,10 +182,10 @@ impl Collection {
                             wal_path.display()
                         ))
                     })?;
-                    Self::apply_upsert(&mut memtable, parsed);
+                    Self::apply_upsert(&mut memtable, &mut deleted, &segments, parsed);
                 }
                 WalRecord::Delete { id, .. } => {
-                    Self::apply_delete(&mut memtable, &mut deleted, &id);
+                    Self::apply_delete(&mut memtable, &mut deleted, &segments, &id);
                 }
             }
         }
@@ -177,7 +206,7 @@ impl Collection {
             schema,
             layout: layout.clone(),
             config: config.clone(),
-            inner: RwLock::new(Inner { state, wal, memtable, deleted, next_seq }),
+            inner: RwLock::new(Inner { state, wal, memtable, segments, deleted, next_seq }),
         })
     }
 
@@ -221,11 +250,17 @@ impl Collection {
             inner.wal.append_batch(&records)?;
             inner.next_seq = first_seq + accepted.len() as u64;
 
-            let memtable = &mut inner.memtable;
-            for (i, parsed) in accepted {
-                let id = parsed.id.clone();
-                Self::apply_upsert(memtable, parsed);
-                results[i] = Some(DocOutcome::ok(id));
+            {
+                let Inner { memtable, deleted, segments, .. } = &mut *inner;
+                for (i, parsed) in accepted {
+                    let id = parsed.id.clone();
+                    Self::apply_upsert(memtable, deleted, segments, parsed);
+                    results[i] = Some(DocOutcome::ok(id));
+                }
+            }
+
+            if Self::needs_flush_locked(&inner, &self.config) {
+                Self::flush_locked(&mut inner, &self.schema, &self.layout, &self.config)?;
             }
         }
 
@@ -256,20 +291,24 @@ impl Collection {
         inner.wal.append(&WalRecordRef::Delete { seq, id })?;
         inner.next_seq = seq + 1;
 
-        let Inner { memtable, deleted, .. } = &mut *inner;
-        Ok(Self::apply_delete(memtable, deleted, id))
+        let removed = {
+            let Inner { memtable, deleted, segments, .. } = &mut *inner;
+            Self::apply_delete(memtable, deleted, segments, id)
+        };
+
+        if Self::needs_flush_locked(&inner, &self.config) {
+            Self::flush_locked(&mut inner, &self.schema, &self.layout, &self.config)?;
+        }
+
+        Ok(removed)
     }
 
     /// Fetch a document's source by id.
     pub fn get(&self, id: &str) -> Result<Json> {
         let inner = self.inner.read();
-        match Self::lookup(&inner, id).and_then(|doc_id| inner.memtable.get(doc_id)) {
-            Some(doc) => Ok(doc.source.clone()),
-            None => Err(Error::DocumentNotFound {
-                collection: self.schema.name.clone(),
-                id: id.to_string(),
-            }),
-        }
+        Self::lookup(&inner, id).and_then(|doc_id| Self::doc_source(&inner, doc_id)).ok_or_else(
+            || Error::DocumentNotFound { collection: self.schema.name.clone(), id: id.to_string() },
+        )
     }
 
     /// Run a search (PRD §7.3).
@@ -281,7 +320,7 @@ impl Collection {
         let request = SearchRequest::resolve(params, &self.schema)?;
 
         let inner = self.inner.read();
-        let ctx = SearchContext::new(&self.schema, vec![&inner.memtable], &inner.deleted);
+        let ctx = SearchContext::new(&self.schema, Self::sources(&inner), &inner.deleted);
         let outcome = execute(&ctx, &request);
 
         let hits = outcome
@@ -290,8 +329,8 @@ impl Collection {
             .filter_map(|scored| {
                 // A hit whose document cannot be fetched would mean the index
                 // and the doc store disagree; skip rather than serve a hole.
-                let doc = inner.memtable.get(scored.doc_id)?;
-                Some(Hit { document: doc.source.clone(), text_match: scored.score })
+                let document = Self::doc_source(&inner, scored.doc_id)?;
+                Some(Hit { document, text_match: scored.score })
             })
             .collect();
 
@@ -314,7 +353,7 @@ impl Collection {
         let request = SuggestRequest::resolve(params, &self.schema)?;
 
         let inner = self.inner.read();
-        let ctx = SearchContext::new(&self.schema, vec![&inner.memtable], &inner.deleted);
+        let ctx = SearchContext::new(&self.schema, Self::sources(&inner), &inner.deleted);
         let suggestions = suggest(&ctx, &request);
 
         Ok(SuggestResponse { suggestions, search_time_ms: started.elapsed().as_millis() as u64 })
@@ -328,9 +367,18 @@ impl Collection {
 
     pub fn stats(&self) -> CollectionStats {
         let inner = self.inner.read();
+        // Not `inner.state.committed_doc_count()`: that subtracts
+        // `state.deleted`, the on-disk snapshot as of the *last* flush.
+        // `inner.deleted` is the live tombstone set, which grows on every
+        // delete or upsert-supersedes-a-segment-doc between flushes — using
+        // the stale snapshot here would overcount until the next flush
+        // happens to catch up.
+        let segment_docs: u64 = inner.state.segments.iter().map(|s| s.doc_count as u64).sum();
+        let num_documents =
+            segment_docs.saturating_sub(inner.deleted.len()) + inner.memtable.len() as u64;
         CollectionStats {
             name: self.schema.name.clone(),
-            num_documents: inner.state.committed_doc_count() + inner.memtable.len() as u64,
+            num_documents,
             num_segments: inner.state.segments.len(),
             memtable_documents: inner.memtable.len(),
             memtable_bytes: inner.memtable.heap_bytes(),
@@ -341,9 +389,18 @@ impl Collection {
 
     /// Whether the memtable has grown past its flush thresholds.
     pub fn needs_flush(&self) -> bool {
-        let inner = self.inner.read();
-        inner.memtable.len() >= self.config.max_memtable_docs
-            || inner.memtable.heap_bytes() >= self.config.max_memtable_bytes
+        Self::needs_flush_locked(&self.inner.read(), &self.config)
+    }
+
+    /// Flush the memtable into a new immutable segment, if anything has been
+    /// allocated since the last flush. Returns whether a flush happened.
+    ///
+    /// Ordinarily triggered automatically once a write crosses
+    /// [`EngineConfig::max_memtable_docs`] or `max_memtable_bytes`; exposed
+    /// directly for tests and for an operator forcing an early flush.
+    pub fn flush(&self) -> Result<bool> {
+        let mut inner = self.inner.write();
+        Self::flush_locked(&mut inner, &self.schema, &self.layout, &self.config)
     }
 
     /// Data directory this collection occupies.
@@ -353,43 +410,162 @@ impl Collection {
 
     // --- internals -------------------------------------------------------
 
+    fn needs_flush_locked(inner: &Inner, config: &EngineConfig) -> bool {
+        inner.memtable.len() >= config.max_memtable_docs
+            || inner.memtable.heap_bytes() >= config.max_memtable_bytes
+    }
+
+    /// Runs under the same write-lock acquisition as the mutation that
+    /// triggered it — encoding, committing, and retiring the old WAL
+    /// generation all happen before any other write can observe `inner`.
+    /// Splitting this into separate lock acquisitions would let a concurrent
+    /// write's WAL record land with a `seq` at or below the `applied_seq`
+    /// this flush is about to commit, silently excluding it from replay
+    /// forever.
+    fn flush_locked(
+        inner: &mut Inner,
+        schema: &CollectionSchema,
+        layout: &Layout,
+        config: &EngineConfig,
+    ) -> Result<bool> {
+        // Not `memtable.is_empty()`: a memtable can hold zero *live* documents
+        // (everything since the last flush was also deleted) while still
+        // holding postings and columns that need reclaiming — exactly the
+        // case `heap_bytes()`-driven flushing exists to catch.
+        if inner.memtable.next_doc_id() == inner.memtable.base() {
+            return Ok(false);
+        }
+
+        let segment_id = inner.state.next_segment_id;
+        let encoded = encode(&inner.memtable, schema)?;
+        let paths = segment_file_paths(layout, &schema.name, segment_id);
+
+        write_atomic(&paths.terms, &encoded.terms)?;
+        write_atomic(&paths.ids, &encoded.ids)?;
+        write_atomic(&paths.post, &encoded.post)?;
+        write_atomic(&paths.col, &encoded.col)?;
+        write_atomic(&paths.doc, &encoded.doc)?;
+        sync_dir(&layout.segments_dir(&schema.name))?;
+
+        let new_wal_generation = inner.state.wal_generation + 1;
+        let new_wal =
+            Wal::open(layout.wal_file(&schema.name, new_wal_generation), config.sync_policy)?;
+
+        let mut new_state = inner.state.clone();
+        new_state.next_segment_id += 1;
+        new_state.next_doc_id = inner.memtable.next_doc_id();
+        new_state.applied_seq = inner.next_seq - 1;
+        new_state.wal_generation = new_wal_generation;
+        new_state.deleted = inner.deleted.iter().collect();
+        new_state.segments.push(SegmentRef {
+            id: segment_id,
+            doc_count: inner.memtable.len() as u32,
+            min_doc_id: inner.memtable.base(),
+            max_doc_id: inner.memtable.next_doc_id() - 1,
+        });
+
+        // The commit point: a crash before this leaves the previous state
+        // intact and the segment files just written orphaned but harmless,
+        // since nothing outside `state.json` ever names a segment id.
+        meta::write_state(layout, &schema.name, &new_state)?;
+
+        // Everything below is the in-memory mirror of what was just made
+        // durable. `inner.state` in particular must be kept current, not
+        // just written to disk — the *next* flush reads `inner.state` to
+        // compute `next_segment_id` and to extend `segments`, and a stale
+        // read here would silently drop this segment's `SegmentRef` from
+        // that later write even though its files are still on disk.
+        inner.state = new_state;
+        inner.segments.push(Arc::new(SegmentReader::open(&paths, schema)?));
+        inner.memtable = MemTable::new(inner.state.next_doc_id, schema);
+        let old_wal = std::mem::replace(&mut inner.wal, new_wal);
+
+        // Last: losing this before the state.json rename would be
+        // unrecoverable (the WAL is the only durable copy), but losing it
+        // after is just a harmless leftover file.
+        old_wal.remove()?;
+
+        Ok(true)
+    }
+
+    /// Every source a search or suggest request reads through: the memtable,
+    /// then every committed segment, oldest first — matching the executor's
+    /// "memtable first, then committed segments" contract.
+    fn sources(inner: &Inner) -> Vec<&dyn IndexSource> {
+        let mut sources: Vec<&dyn IndexSource> = Vec::with_capacity(1 + inner.segments.len());
+        sources.push(&inner.memtable);
+        sources.extend(inner.segments.iter().map(|s| s.as_ref() as &dyn IndexSource));
+        sources
+    }
+
+    /// A document's stored source, wherever it lives.
+    fn doc_source(inner: &Inner, doc_id: DocId) -> Option<Json> {
+        if let Some(doc) = inner.memtable.get(doc_id) {
+            return Some(doc.source.clone());
+        }
+        inner.segments.iter().rev().find_map(|segment| segment.get(doc_id))
+    }
+
     /// Resolve a user-facing id to an internal doc id.
     ///
     /// The memtable holds the newest version of everything written since the
-    /// last flush, so it is consulted first; only then do committed segments
-    /// matter.
+    /// last flush, so it is consulted first; only then do committed segments,
+    /// newest first. A segment-resident id tombstoned by a later delete must
+    /// never be returned.
     fn lookup(inner: &Inner, id: &str) -> Option<DocId> {
         if let Some(doc_id) = inner.memtable.lookup(id) {
             return Some(doc_id);
         }
-        // Segments are searched newest-first once they exist (M2); a tombstoned
-        // doc id must never be returned.
-        let _ = &inner.deleted;
-        None
+        inner.segments.iter().rev().find_map(|segment| segment.lookup_id(id)).filter(|doc_id| {
+            !inner.deleted.contains(*doc_id)
+        })
     }
 
-    /// Insert a document, retiring any previous version of the same id.
-    fn apply_upsert(memtable: &mut MemTable, doc: ParsedDocument) {
-        let previous = memtable.lookup(&doc.id);
+    /// Insert a document, retiring any previous version of the same id —
+    /// whether that version lives in the memtable or a committed segment.
+    fn apply_upsert(
+        memtable: &mut MemTable,
+        deleted: &mut RoaringBitmap,
+        segments: &[Arc<SegmentReader>],
+        doc: ParsedDocument,
+    ) {
+        let id = doc.id.clone();
+        let previous_in_memtable = memtable.lookup(&id);
         // Insert first: the memtable keys ids to the newest doc id, and
         // removing the old version afterwards must not clear that mapping.
         memtable.insert(doc);
-        if let Some(old) = previous {
+        if let Some(old) = previous_in_memtable {
             memtable.remove(old);
+        } else {
+            // The previous version, if any, lives in a committed segment —
+            // tombstone it there so the same id doesn't resolve to two
+            // documents (stale in the segment, fresh in the memtable).
+            if let Some(old_doc_id) =
+                segments.iter().rev().find_map(|segment| segment.lookup_id(&id))
+            {
+                deleted.insert(old_doc_id);
+            }
         }
     }
 
     /// Retire the current version of `id`, if any. Returns whether it existed.
-    fn apply_delete(memtable: &mut MemTable, deleted: &mut RoaringBitmap, id: &str) -> bool {
-        match memtable.lookup(id) {
-            Some(doc_id) => memtable.remove(doc_id),
-            None => {
-                // Nothing in memory; once segments exist the id is resolved
-                // against them and tombstoned here.
-                let _ = deleted;
-                false
-            }
+    fn apply_delete(
+        memtable: &mut MemTable,
+        deleted: &mut RoaringBitmap,
+        segments: &[Arc<SegmentReader>],
+        id: &str,
+    ) -> bool {
+        if let Some(doc_id) = memtable.lookup(id) {
+            return memtable.remove(doc_id);
         }
+        let Some(doc_id) = segments.iter().rev().find_map(|segment| segment.lookup_id(id)) else {
+            return false;
+        };
+        if deleted.contains(doc_id) {
+            return false; // already tombstoned — deleting twice is not an error
+        }
+        deleted.insert(doc_id);
+        true
     }
 
     #[cfg(test)]
@@ -633,5 +809,183 @@ mod tests {
         }
         let c = Collection::open(&layout, "products", &config).unwrap();
         assert_eq!(c.stats().num_documents, 1);
+    }
+
+    // --- segment flush -----------------------------------------------------
+
+    #[test]
+    fn flush_produces_a_segment_and_empties_the_memtable() {
+        let h = Harness::new();
+        let c = h.create();
+        c.upsert_batch(vec![product("1", "Wireless Mouse", 2999), product("2", "Keyboard", 4999)])
+            .unwrap();
+
+        assert!(c.flush().unwrap());
+        assert_eq!(c.stats().num_segments, 1);
+        assert_eq!(c.stats().memtable_documents, 0);
+        assert_eq!(c.stats().num_documents, 2);
+        assert_eq!(c.get("1").unwrap()["title"], json!("Wireless Mouse"));
+
+        assert!(!c.flush().unwrap(), "nothing allocated since the last flush");
+    }
+
+    #[test]
+    fn flush_triggers_automatically_past_the_doc_threshold() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = Layout::new(dir.path());
+        layout.initialize().unwrap();
+        let config = EngineConfig::new(dir.path()).with_max_memtable_docs(2);
+
+        let c = Collection::create(&layout, schema(), &config).unwrap();
+        c.upsert_batch(vec![product("1", "a", 1), product("2", "b", 2)]).unwrap();
+
+        assert_eq!(c.stats().num_segments, 1, "crossing the threshold must flush automatically");
+        assert_eq!(c.stats().memtable_documents, 0);
+        assert_eq!(c.get("1").unwrap()["title"], json!("a"));
+    }
+
+    #[test]
+    fn flushed_data_survives_a_restart_with_replay_bounded_to_post_flush_records() {
+        let h = Harness::new();
+        {
+            let c = h.create();
+            c.upsert_batch(vec![product("1", "a", 1), product("2", "b", 2)]).unwrap();
+            assert!(c.flush().unwrap());
+            c.upsert(product("3", "c", 3)).unwrap(); // one record after the flush
+        }
+
+        let c = h.reopen();
+        assert_eq!(c.stats().num_documents, 3);
+        assert_eq!(c.get("1").unwrap()["title"], json!("a"));
+        assert_eq!(c.get("3").unwrap()["title"], json!("c"));
+
+        // Replay must not need anything the segment already captured.
+        let generation = c.read_inner().state.wal_generation;
+        let records = wal::read(&h.layout.wal_file("products", generation)).unwrap().records;
+        assert_eq!(records.len(), 1, "only the post-flush record should remain in the WAL");
+    }
+
+    #[test]
+    fn upserting_a_segment_resident_document_is_visible_exactly_once() {
+        let h = Harness::new();
+        let c = h.create();
+        c.upsert(product("1", "Old", 100)).unwrap();
+        assert!(c.flush().unwrap());
+
+        c.upsert(product("1", "New", 200)).unwrap();
+
+        assert_eq!(c.get("1").unwrap()["title"], json!("New"));
+        assert_eq!(
+            c.stats().num_documents,
+            1,
+            "the segment's stale copy must be tombstoned, not left visible alongside the new one"
+        );
+    }
+
+    #[test]
+    fn deleting_a_segment_resident_document_is_durable_across_a_restart() {
+        let h = Harness::new();
+        {
+            let c = h.create();
+            c.upsert(product("1", "Mouse", 100)).unwrap();
+            assert!(c.flush().unwrap());
+
+            assert!(c.delete("1").unwrap());
+            assert!(!c.delete("1").unwrap(), "deleting an already-tombstoned segment doc is a no-op");
+            assert!(matches!(c.get("1"), Err(Error::DocumentNotFound { .. })));
+        }
+
+        let c = h.reopen();
+        assert!(matches!(c.get("1"), Err(Error::DocumentNotFound { .. })));
+        assert_eq!(c.stats().num_documents, 0);
+    }
+
+    #[test]
+    fn two_flushes_in_a_row_both_survive_a_restart() {
+        // Regression test: a flush that forgets to keep `inner.state` current
+        // in memory would compute the second flush's `SegmentRef` list from
+        // the stale pre-first-flush state, silently dropping the first
+        // segment from state.json even though its files are still on disk.
+        let h = Harness::new();
+        {
+            let c = h.create();
+            c.upsert(product("1", "a", 1)).unwrap();
+            assert!(c.flush().unwrap());
+            c.upsert(product("2", "b", 2)).unwrap();
+            assert!(c.flush().unwrap());
+            assert_eq!(c.stats().num_segments, 2);
+        }
+
+        let c = h.reopen();
+        assert_eq!(c.stats().num_segments, 2);
+        assert_eq!(c.stats().num_documents, 2);
+        assert_eq!(c.get("1").unwrap()["title"], json!("a"));
+        assert_eq!(c.get("2").unwrap()["title"], json!("b"));
+    }
+
+    #[test]
+    fn an_all_deleted_memtable_still_flushes_cleanly() {
+        let h = Harness::new();
+        let c = h.create();
+        c.upsert(product("1", "a", 1)).unwrap();
+        c.delete("1").unwrap();
+
+        assert!(c.flush().unwrap(), "a doc id was allocated even though nothing is live");
+        assert_eq!(c.stats().num_segments, 1);
+        assert_eq!(c.stats().num_documents, 0);
+        assert!(matches!(c.get("1"), Err(Error::DocumentNotFound { .. })));
+
+        let reopened = h.reopen();
+        assert_eq!(reopened.stats().num_segments, 1);
+        assert_eq!(reopened.stats().num_documents, 0);
+    }
+
+    #[test]
+    fn a_stale_orphaned_segment_id_is_safely_overwritten_by_a_real_flush() {
+        // No directory scan ever runs on open — only ids named in
+        // `state.json` are opened — so files left behind by a crash between
+        // writing segment data and committing state.json are inert, and a
+        // later flush reusing that id must simply overwrite them.
+        let h = Harness::new();
+        let c = h.create();
+
+        std::fs::create_dir_all(h.layout.segments_dir("products")).unwrap();
+        for ext in ["terms", "ids", "post", "col", "doc"] {
+            std::fs::write(h.layout.segment_file("products", 1, ext), b"garbage").unwrap();
+        }
+
+        c.upsert(product("1", "Mouse", 100)).unwrap();
+        assert!(c.flush().unwrap());
+        assert_eq!(c.stats().num_segments, 1);
+        assert_eq!(c.get("1").unwrap()["title"], json!("Mouse"));
+
+        let reopened = h.reopen();
+        assert_eq!(reopened.stats().num_segments, 1);
+        assert_eq!(reopened.get("1").unwrap()["title"], json!("Mouse"));
+    }
+
+    #[test]
+    fn search_and_suggest_see_documents_in_both_memtable_and_segments() {
+        let h = Harness::new();
+        let c = h.create();
+        c.upsert(product("1", "Wireless Mouse", 2999)).unwrap();
+        assert!(c.flush().unwrap());
+        c.upsert(product("2", "Mechanical Keyboard", 8999)).unwrap();
+
+        let results = c
+            .search(SearchParams {
+                q: Some("mouse keyboard".into()),
+                match_mode: Some("any".into()),
+                ..Default::default()
+            })
+            .unwrap();
+        let ids: std::collections::HashSet<_> =
+            results.hits.iter().map(|h| h.document["id"].as_str().unwrap().to_string()).collect();
+        assert!(ids.contains("1"), "the segment-resident document must be found");
+        assert!(ids.contains("2"), "the memtable-resident document must be found");
+
+        let suggestions =
+            c.suggest(SuggestParams { q: Some("mo".into()), ..Default::default() }).unwrap();
+        assert!(!suggestions.suggestions.is_empty());
     }
 }

--- a/crates/tachyon-index/Cargo.toml
+++ b/crates/tachyon-index/Cargo.toml
@@ -13,6 +13,8 @@ tachyon-core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 roaring.workspace = true
+fst.workspace = true
+memmap2.workspace = true
 tracing.workspace = true
 unicode-normalization.workspace = true
 

--- a/crates/tachyon-index/src/columns.rs
+++ b/crates/tachyon-index/src/columns.rs
@@ -127,7 +127,7 @@ fn collect_docs(docs: impl Iterator<Item = DocId>) -> RoaringBitmap {
 }
 
 /// Sorted `(value, doc_id)` pairs for one numeric field.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct NumericColumn {
     sorted: Vec<(NumKey, DocId)>,
     pending: Vec<(NumKey, DocId)>,
@@ -292,10 +292,23 @@ impl NumericColumn {
     pub fn heap_bytes(&self) -> usize {
         self.len() * std::mem::size_of::<(NumKey, DocId)>()
     }
+
+    /// Build a column directly from an already-sorted vector, with no
+    /// `pending` tail — used when decoding a segment, where nothing writes to
+    /// the column again so there is nothing left to amortize.
+    pub fn from_sorted(sorted: Vec<(NumKey, DocId)>) -> NumericColumn {
+        NumericColumn { sorted, pending: Vec::new() }
+    }
+
+    /// Every `(value, doc)` pair this column holds, in no particular order.
+    /// Used by the segment writer, which sorts and filters live docs itself.
+    pub fn iter(&self) -> impl Iterator<Item = (NumKey, DocId)> + '_ {
+        self.sorted.iter().copied().chain(self.pending.iter().copied())
+    }
 }
 
 /// Value → documents, for keyword equality and facets.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct KeywordColumn {
     by_value: HashMap<Box<str>, RoaringBitmap>,
     /// Documents with any value, so `!=` can exclude without resurrecting
@@ -366,6 +379,22 @@ impl KeywordColumn {
     pub fn heap_bytes(&self) -> usize {
         self.value_bytes + self.entries * std::mem::size_of::<DocId>()
     }
+
+    /// Build a column directly from decoded per-value bitmaps — used when
+    /// decoding a segment. Recomputes the running heap-accounting totals
+    /// [`KeywordColumn::push`] normally maintains incrementally.
+    pub fn from_parts(by_value: HashMap<Box<str>, RoaringBitmap>, present: RoaringBitmap) -> KeywordColumn {
+        let value_bytes =
+            by_value.keys().map(|v| v.len() + std::mem::size_of::<Box<str>>() + 32).sum();
+        let entries = by_value.values().map(RoaringBitmap::len).sum::<u64>() as usize;
+        KeywordColumn { by_value, present, value_bytes, entries }
+    }
+
+    /// Every distinct value with its bitmap. Used by the segment writer,
+    /// which filters and re-serializes them itself.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &RoaringBitmap)> {
+        self.by_value.iter().map(|(v, b)| (v.as_ref(), b))
+    }
 }
 
 /// All columns of one collection, addressed by field id.
@@ -393,6 +422,15 @@ impl Columns {
             keyword.push(k);
         }
 
+        Columns { numeric, keyword }
+    }
+
+    /// Build directly from decoded per-field columns — used when decoding a
+    /// segment, in place of [`Columns::new`]'s schema-driven allocation.
+    pub fn from_parts(
+        numeric: Vec<Option<NumericColumn>>,
+        keyword: Vec<Option<KeywordColumn>>,
+    ) -> Columns {
         Columns { numeric, keyword }
     }
 

--- a/crates/tachyon-index/src/inverted.rs
+++ b/crates/tachyon-index/src/inverted.rs
@@ -206,6 +206,13 @@ impl InvertedIndex {
         self.terms.keys().map(|k| k.as_ref())
     }
 
+    /// Every term, in sorted order, with its postings per field — including
+    /// postings for since-deleted documents. Used by the segment writer,
+    /// which filters those out itself against the memtable's live set.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &[(FieldId, FieldPostings)])> {
+        self.terms.iter().map(|(term, entry)| (term.as_ref(), entry.fields.as_slice()))
+    }
+
     /// Terms starting with `prefix`, in sorted order (PRD §7.5, §7.3 prefix
     /// matching). Walks only the matching range, not the whole dictionary.
     pub fn terms_with_prefix<'a>(&'a self, prefix: &'a str) -> impl Iterator<Item = &'a str> + 'a {

--- a/crates/tachyon-index/src/lib.rs
+++ b/crates/tachyon-index/src/lib.rs
@@ -7,6 +7,7 @@ pub mod columns;
 pub mod fuzzy;
 pub mod inverted;
 pub mod memtable;
+pub mod segment;
 pub mod source;
 pub mod tokenizer;
 
@@ -14,5 +15,6 @@ pub use columns::{Columns, KeywordColumn, NumKey, NumericColumn};
 pub use fuzzy::{distance_within, FuzzyMatcher};
 pub use inverted::{DocPosting, FieldPostings, InvertedIndex};
 pub use memtable::{MemTable, StoredDoc};
+pub use segment::{encode, EncodedSegment, SegmentFilePaths, SegmentReader};
 pub use source::IndexSource;
 pub use tokenizer::{tokenize, Token};

--- a/crates/tachyon-index/src/segment/codec.rs
+++ b/crates/tachyon-index/src/segment/codec.rs
@@ -1,0 +1,1051 @@
+//! Segment byte codec, v2: encode a live view of a [`MemTable`] into five
+//! segment blobs, and decode them back — lazily. Nothing here holds a whole
+//! segment's postings, columns, or documents in memory at once; every decode
+//! function here takes the byte slice it needs and returns just the one
+//! term's postings, one field's column, or one document's value the caller
+//! asked for. `tachyon-engine`'s `SegmentReader` wraps these around an mmap'd
+//! file per blob and calls them per query.
+//!
+//! No filesystem access here — writing the bytes to disk and committing them
+//! is `tachyon-engine`'s job, per `tachyon-storage`'s "segment *contents* are
+//! the index crate's business, segment *lifecycle* is the engine's" split.
+//!
+//! # Holes
+//!
+//! A document deleted from the memtable before ever being flushed must never
+//! reach a segment. Every encoder here filters against `live`, a bitmap of
+//! doc ids the memtable still holds — postings, columns, and doc records for
+//! anything else are dropped for good; that's how a flush reclaims the
+//! memory [`crate::inverted::InvertedIndex`]'s "postings are never removed"
+//! policy leaves behind.
+
+use std::collections::HashMap;
+
+use roaring::RoaringBitmap;
+use serde_json::Value as Json;
+
+use tachyon_core::{CollectionSchema, DocId, Error, FieldId, Result, Value};
+
+use crate::columns::{KeywordColumn, NumKey, NumericColumn};
+use crate::inverted::{DocPosting, FieldPostings};
+use crate::memtable::MemTable;
+
+use super::format::{
+    bytes_at, f64_at, i64_at, u32_at, u8_at, write_bytes, write_f64, write_header, write_i64,
+    write_str, write_u32, write_u64, write_u8, Cursor, COL_MAGIC, DOC_MAGIC, HEADER_LEN,
+    IDS_MAGIC, POST_MAGIC, TERMS_MAGIC,
+};
+
+/// The five byte blobs one segment is made of, ready to be written to disk.
+pub struct EncodedSegment {
+    pub terms: Vec<u8>,
+    pub ids: Vec<u8>,
+    pub post: Vec<u8>,
+    pub col: Vec<u8>,
+    pub doc: Vec<u8>,
+}
+
+/// Encode every live document in `memtable` into segment bytes.
+pub fn encode(memtable: &MemTable, schema: &CollectionSchema) -> Result<EncodedSegment> {
+    let live: RoaringBitmap = memtable.iter().map(|(id, _)| id).collect();
+
+    let (terms, post) = encode_postings(memtable, &live, schema)?;
+    let ids = encode_ids(memtable)?;
+    let col = encode_columns(memtable, &live, schema);
+    let doc = encode_docs(memtable, schema);
+
+    Ok(EncodedSegment { terms, ids, post, col, doc })
+}
+
+/// Wrap the payload of an `fst::Map` (built in memory) with the standard
+/// segment header, so every file — FST-backed or not — starts the same way.
+fn wrap_fst(magic: &[u8; 8], fst_bytes: Vec<u8>) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(HEADER_LEN + fst_bytes.len());
+    write_header(&mut buf, magic);
+    buf.extend_from_slice(&fst_bytes);
+    buf
+}
+
+/// Validate a header and return the byte offset where the payload after it
+/// begins — used by callers that mmap the file starting past the header
+/// (`.terms`/`.ids`, whose `fst::Map` needs to see nothing but its own bytes).
+pub fn validate_header(bytes: &[u8], magic: &[u8; 8], what: &'static str) -> Result<usize> {
+    let mut cur = Cursor::new(bytes, what);
+    cur.read_header(magic)?;
+    Ok(cur.position())
+}
+
+// --- ids -------------------------------------------------------------------
+
+/// `id -> doc_id`, an `fst::Map` exactly like `.terms` — sorted, mmap'd,
+/// nothing resident but the offset of the file itself. Replaces holding a
+/// `HashMap<Box<str>, DocId>` for the whole segment.
+fn encode_ids(memtable: &MemTable) -> Result<Vec<u8>> {
+    let mut pairs: Vec<(&str, DocId)> =
+        memtable.iter().map(|(doc_id, doc)| (doc.id.as_str(), doc_id)).collect();
+    pairs.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+
+    let mut builder = fst::MapBuilder::memory();
+    for (id, doc_id) in &pairs {
+        builder
+            .insert(id, *doc_id as u64)
+            .map_err(|e| Error::internal(format!("building segment id index: {e}")))?;
+    }
+    let fst_bytes = builder
+        .into_inner()
+        .map_err(|e| Error::internal(format!("building segment id index: {e}")))?;
+    Ok(wrap_fst(IDS_MAGIC, fst_bytes))
+}
+
+// --- postings + terms --------------------------------------------------
+
+fn encode_postings(
+    memtable: &MemTable,
+    live: &RoaringBitmap,
+    schema: &CollectionSchema,
+) -> Result<(Vec<u8>, Vec<u8>)> {
+    let num_fields = schema.fields.len();
+    let mut field_doc_count = vec![0u32; num_fields];
+    let mut field_total_len = vec![0u64; num_fields];
+    for (_, doc) in memtable.iter() {
+        for (field, &len) in doc.field_lengths.iter().enumerate() {
+            if len > 0 {
+                field_doc_count[field] += 1;
+                field_total_len[field] += len as u64;
+            }
+        }
+    }
+
+    // Surviving terms, in the dictionary's existing sorted order, with dead
+    // postings filtered out and any term/field left empty by that dropped.
+    struct TermBlock<'a> {
+        term: &'a str,
+        fields: Vec<(FieldId, Vec<&'a DocPosting>)>,
+    }
+    let mut blocks: Vec<TermBlock> = Vec::new();
+    for (term, fields) in memtable.index().iter() {
+        let mut kept: Vec<(FieldId, Vec<&DocPosting>)> = Vec::new();
+        for (field, postings) in fields {
+            let docs: Vec<&DocPosting> =
+                postings.docs.iter().filter(|d| live.contains(d.doc_id)).collect();
+            if !docs.is_empty() {
+                kept.push((*field, docs));
+            }
+        }
+        if !kept.is_empty() {
+            blocks.push(TermBlock { term, fields: kept });
+        }
+    }
+
+    // fst requires ascending-key insertion; the dictionary is already sorted.
+    let mut builder = fst::MapBuilder::memory();
+    for (term_id, block) in blocks.iter().enumerate() {
+        builder
+            .insert(block.term, term_id as u64)
+            .map_err(|e| Error::internal(format!("building segment term dictionary: {e}")))?;
+    }
+    let fst_bytes = builder
+        .into_inner()
+        .map_err(|e| Error::internal(format!("building segment term dictionary: {e}")))?;
+    let terms = wrap_fst(TERMS_MAGIC, fst_bytes);
+
+    // Postings data, term by term, with an offset table so any one term's
+    // block can be located and decoded without touching the others.
+    let mut data = Vec::new();
+    let mut offsets = Vec::with_capacity(blocks.len());
+    for block in &blocks {
+        offsets.push(data.len() as u64);
+        write_u32(&mut data, block.fields.len() as u32);
+        for (field, docs) in &block.fields {
+            write_u32(&mut data, *field as u32);
+            write_u32(&mut data, docs.len() as u32);
+            for posting in docs {
+                write_u32(&mut data, posting.doc_id);
+                write_u32(&mut data, posting.positions.len() as u32);
+                for &p in &posting.positions {
+                    write_u32(&mut data, p);
+                }
+            }
+        }
+    }
+
+    let mut post = Vec::new();
+    write_header(&mut post, POST_MAGIC);
+    write_u32(&mut post, num_fields as u32);
+    for f in 0..num_fields {
+        write_u32(&mut post, field_doc_count[f]);
+        write_u64(&mut post, field_total_len[f]);
+    }
+    write_u32(&mut post, blocks.len() as u32);
+    for off in &offsets {
+        write_u64(&mut post, *off);
+    }
+    post.extend_from_slice(&data);
+
+    Ok((terms, post))
+}
+
+/// The small, eager part of `.post`: field stats and the offset table. O(num
+/// fields + num terms), never O(num postings).
+pub(crate) struct PostHeader {
+    pub field_doc_count: Vec<u32>,
+    pub field_total_len: Vec<u64>,
+    /// Byte offset of term `i`'s block, relative to the start of the file.
+    offsets: Vec<u64>,
+}
+
+pub(crate) fn decode_post_header(bytes: &[u8]) -> Result<PostHeader> {
+    let mut cur = Cursor::new(bytes, "segment postings");
+    cur.read_header(POST_MAGIC)?;
+
+    let num_fields = cur.read_u32()? as usize;
+    let mut field_doc_count = Vec::with_capacity(num_fields);
+    let mut field_total_len = Vec::with_capacity(num_fields);
+    for _ in 0..num_fields {
+        field_doc_count.push(cur.read_u32()?);
+        field_total_len.push(cur.read_u64()?);
+    }
+
+    // The offset table stores byte positions relative to the start of the
+    // *data* section, i.e. right after the table itself — read it straight,
+    // then add back where the data section begins so lookups are absolute
+    // offsets into the file.
+    let num_terms = cur.read_u32()? as usize;
+    let mut offsets = Vec::with_capacity(num_terms);
+    for _ in 0..num_terms {
+        offsets.push(cur.read_u64()?);
+    }
+    let data_start = cur.position() as u64;
+    for off in &mut offsets {
+        *off += data_start;
+    }
+
+    Ok(PostHeader { field_doc_count, field_total_len, offsets })
+}
+
+const POST_BLOCK_WHAT: &str = "segment postings (term block)";
+
+fn term_block<'a>(bytes: &'a [u8], header: &PostHeader, term_id: u64) -> Result<&'a [u8]> {
+    let term_id = term_id as usize;
+    let start = *header
+        .offsets
+        .get(term_id)
+        .ok_or_else(|| Error::corruption(format!("{POST_BLOCK_WHAT}: term id out of range")))?
+        as usize;
+    let end = if term_id + 1 < header.offsets.len() {
+        header.offsets[term_id + 1] as usize
+    } else {
+        bytes.len()
+    };
+    bytes
+        .get(start..end)
+        .ok_or_else(|| Error::corruption(format!("{POST_BLOCK_WHAT}: offset table out of range")))
+}
+
+/// Decode exactly one term's postings (every field it occurs in), by the
+/// dense id `.terms`' FST maps it to. The only allocation this causes is for
+/// that one term's data — nothing else in the segment is touched.
+pub(crate) fn decode_term_postings(
+    bytes: &[u8],
+    header: &PostHeader,
+    term_id: u64,
+) -> Result<Vec<(FieldId, FieldPostings)>> {
+    let what = POST_BLOCK_WHAT;
+    let block = term_block(bytes, header, term_id)?;
+
+    let mut cur = Cursor::new(block, what);
+    let num_term_fields = cur.read_u32()? as usize;
+    let mut fields = Vec::with_capacity(num_term_fields);
+    for _ in 0..num_term_fields {
+        let field = cur.read_u32()? as FieldId;
+        let num_docs = cur.read_u32()? as usize;
+        let mut docs = Vec::with_capacity(num_docs);
+        for _ in 0..num_docs {
+            let doc_id = cur.read_u32()?;
+            let num_positions = cur.read_u32()? as usize;
+            let mut positions = Vec::with_capacity(num_positions);
+            for _ in 0..num_positions {
+                positions.push(cur.read_u32()?);
+            }
+            docs.push(DocPosting { doc_id, positions });
+        }
+        fields.push((field, FieldPostings { docs }));
+    }
+    Ok(fields)
+}
+
+/// Just the document ids one term occurs in, for one field — no positions
+/// decoded or allocated. `doc_freq`/`live_doc_freq` only ever need a count or
+/// a liveness check, never the positions, and autocomplete calls both across
+/// every candidate term and every source: decoding full posting lists
+/// (positions included) just to answer "how many" would mean paying for data
+/// nobody asked for on the hottest part of that path.
+pub(crate) fn decode_term_field_doc_ids(
+    bytes: &[u8],
+    header: &PostHeader,
+    term_id: u64,
+    field: FieldId,
+) -> Result<Vec<DocId>> {
+    let what = POST_BLOCK_WHAT;
+    let block = term_block(bytes, header, term_id)?;
+
+    let mut cur = Cursor::new(block, what);
+    let num_term_fields = cur.read_u32()? as usize;
+    for _ in 0..num_term_fields {
+        let this_field = cur.read_u32()? as FieldId;
+        let num_docs = cur.read_u32()? as usize;
+        if this_field != field {
+            // Skip every doc in a field nobody asked about, positions
+            // included — still no allocation, just cursor arithmetic.
+            for _ in 0..num_docs {
+                let _doc_id = cur.read_u32()?;
+                let num_positions = cur.read_u32()? as usize;
+                cur.skip(num_positions * 4)?;
+            }
+            continue;
+        }
+        let mut doc_ids = Vec::with_capacity(num_docs);
+        for _ in 0..num_docs {
+            doc_ids.push(cur.read_u32()?);
+            let num_positions = cur.read_u32()? as usize;
+            cur.skip(num_positions * 4)?;
+        }
+        return Ok(doc_ids);
+    }
+    Ok(Vec::new())
+}
+
+// --- columns -----------------------------------------------------------
+
+const FIELD_TAG_NONE: u8 = 0;
+const FIELD_TAG_NUMERIC: u8 = 1;
+const FIELD_TAG_KEYWORD: u8 = 2;
+const NUMKEY_TAG_INT: u8 = 0;
+const NUMKEY_TAG_FLOAT: u8 = 1;
+
+fn encode_columns(memtable: &MemTable, live: &RoaringBitmap, schema: &CollectionSchema) -> Vec<u8> {
+    let columns = memtable.columns();
+    let mut data = Vec::new();
+    let mut directory: Vec<(u8, u32, u32)> = Vec::with_capacity(schema.fields.len());
+
+    for field_id in 0..schema.fields.len() as FieldId {
+        if let Some(col) = columns.numeric(field_id) {
+            let start = data.len();
+            let mut pairs: Vec<(NumKey, DocId)> =
+                col.iter().filter(|(_, d)| live.contains(*d)).collect();
+            pairs.sort_by(|a, b| a.0.cmp_key(&b.0).then(a.1.cmp(&b.1)));
+            write_u32(&mut data, pairs.len() as u32);
+            for (key, doc_id) in pairs {
+                match key {
+                    NumKey::Int(i) => {
+                        write_u8(&mut data, NUMKEY_TAG_INT);
+                        write_i64(&mut data, i);
+                    }
+                    NumKey::Float(f) => {
+                        write_u8(&mut data, NUMKEY_TAG_FLOAT);
+                        write_f64(&mut data, f);
+                    }
+                }
+                write_u32(&mut data, doc_id);
+            }
+            directory.push((FIELD_TAG_NUMERIC, start as u32, (data.len() - start) as u32));
+        } else if let Some(col) = columns.keyword(field_id) {
+            let start = data.len();
+            let values: Vec<(&str, RoaringBitmap)> = col
+                .iter()
+                .filter_map(|(v, b)| {
+                    let mut filtered = b.clone();
+                    filtered &= live;
+                    (!filtered.is_empty()).then_some((v, filtered))
+                })
+                .collect();
+            write_u32(&mut data, values.len() as u32);
+            for (value, bitmap) in &values {
+                write_str(&mut data, value);
+                let mut ser = Vec::new();
+                bitmap.serialize_into(&mut ser).expect("writing to a Vec cannot fail");
+                write_bytes(&mut data, &ser);
+            }
+            let mut present = col.present().clone();
+            present &= live;
+            let mut ser = Vec::new();
+            present.serialize_into(&mut ser).expect("writing to a Vec cannot fail");
+            write_bytes(&mut data, &ser);
+            directory.push((FIELD_TAG_KEYWORD, start as u32, (data.len() - start) as u32));
+        } else {
+            directory.push((FIELD_TAG_NONE, 0, 0));
+        }
+    }
+
+    // The directory's own size is known up front (fixed 9 bytes per field),
+    // so each entry's absolute offset can be computed directly — no need to
+    // write placeholders and patch them after the fact.
+    let data_start = (HEADER_LEN + 4 + schema.fields.len() * 9) as u32;
+
+    let mut buf = Vec::new();
+    write_header(&mut buf, COL_MAGIC);
+    write_u32(&mut buf, schema.fields.len() as u32);
+    for &(tag, offset, length) in &directory {
+        write_u8(&mut buf, tag);
+        write_u32(&mut buf, if tag == FIELD_TAG_NONE { 0 } else { offset + data_start });
+        write_u32(&mut buf, length);
+    }
+    buf.extend_from_slice(&data);
+    buf
+}
+
+struct ColEntry {
+    tag: u8,
+    offset: u32,
+    length: u32,
+}
+
+pub(crate) struct ColHeader {
+    directory: Vec<ColEntry>,
+}
+
+pub(crate) fn decode_col_header(bytes: &[u8]) -> Result<ColHeader> {
+    let mut cur = Cursor::new(bytes, "segment columns");
+    cur.read_header(COL_MAGIC)?;
+    let num_fields = cur.read_u32()? as usize;
+    let mut directory = Vec::with_capacity(num_fields);
+    for _ in 0..num_fields {
+        let tag = cur.read_u8()?;
+        let offset = cur.read_u32()?;
+        let length = cur.read_u32()?;
+        directory.push(ColEntry { tag, offset, length });
+    }
+    Ok(ColHeader { directory })
+}
+
+pub(crate) fn decode_numeric_column(
+    bytes: &[u8],
+    header: &ColHeader,
+    field: FieldId,
+) -> Result<Option<NumericColumn>> {
+    let Some(entry) = header.directory.get(field as usize) else { return Ok(None) };
+    if entry.tag != FIELD_TAG_NUMERIC {
+        return Ok(None);
+    }
+    let slice = bytes_at(bytes, entry.offset as usize, entry.length as usize, "segment columns")?;
+    let mut cur = Cursor::new(slice, "segment columns (numeric field)");
+    let n = cur.read_u32()? as usize;
+    let mut pairs = Vec::with_capacity(n);
+    for _ in 0..n {
+        let key = match cur.read_u8()? {
+            NUMKEY_TAG_INT => NumKey::Int(cur.read_i64()?),
+            NUMKEY_TAG_FLOAT => NumKey::Float(cur.read_f64()?),
+            other => {
+                return Err(Error::corruption(format!("segment columns: bad numeric key tag {other}")))
+            }
+        };
+        let doc_id = cur.read_u32()?;
+        pairs.push((key, doc_id));
+    }
+    Ok(Some(NumericColumn::from_sorted(pairs)))
+}
+
+pub(crate) fn decode_keyword_column(
+    bytes: &[u8],
+    header: &ColHeader,
+    field: FieldId,
+) -> Result<Option<KeywordColumn>> {
+    let Some(entry) = header.directory.get(field as usize) else { return Ok(None) };
+    if entry.tag != FIELD_TAG_KEYWORD {
+        return Ok(None);
+    }
+    let slice = bytes_at(bytes, entry.offset as usize, entry.length as usize, "segment columns")?;
+    let mut cur = Cursor::new(slice, "segment columns (keyword field)");
+    let n = cur.read_u32()? as usize;
+    let mut by_value = HashMap::with_capacity(n);
+    for _ in 0..n {
+        let value = cur.read_str()?.to_string();
+        let ser = cur.read_bytes()?;
+        let bitmap = RoaringBitmap::deserialize_from(ser)?;
+        by_value.insert(value.into_boxed_str(), bitmap);
+    }
+    let ser = cur.read_bytes()?;
+    let present = RoaringBitmap::deserialize_from(ser)?;
+    Ok(Some(KeywordColumn::from_parts(by_value, present)))
+}
+
+// --- doc store -----------------------------------------------------------
+//
+// Four parallel sections, every one addressable in O(1) from a `doc_id`:
+//
+//   field_lengths  dense (end-base)*num_fields*u32          zero-copy read
+//   values_dir     dense (end-base)*num_fields*9 bytes       zero-copy for
+//                                                             scalars, one
+//                                                             offset hop into
+//                                                             `strings` for
+//                                                             text/arrays
+//   source_dir     dense (end-base)*8 bytes (offset,len)     one hop into
+//                                                             `source`, paid
+//                                                             only when a
+//                                                             document is
+//                                                             actually
+//                                                             materialized
+//
+// `field_lengths` is BM25's `|d|`, read once per scored document — it must
+// never cost an allocation, which is why it gets its own flat array instead
+// of living inside a per-doc record that would need decoding to reach it.
+
+const VALUE_TAG_NULL: u8 = 0;
+const VALUE_TAG_BOOL: u8 = 1;
+const VALUE_TAG_INT: u8 = 2;
+const VALUE_TAG_FLOAT: u8 = 3;
+const VALUE_TAG_STR: u8 = 4;
+const VALUE_TAG_ARRAY: u8 = 5;
+
+const VALUE_SLOT_LEN: usize = 9; // 1 tag byte + 8 data bytes
+
+/// The general recursive encoding used for anything that doesn't fit a fixed
+/// 9-byte slot (`Str`, `Array`) — written into the `strings` section and
+/// referenced from a slot by `(offset, length)`.
+fn write_value_full(buf: &mut Vec<u8>, value: &Value) {
+    match value {
+        Value::Null => write_u8(buf, VALUE_TAG_NULL),
+        Value::Bool(b) => {
+            write_u8(buf, VALUE_TAG_BOOL);
+            write_u8(buf, *b as u8);
+        }
+        Value::Int(i) => {
+            write_u8(buf, VALUE_TAG_INT);
+            write_i64(buf, *i);
+        }
+        Value::Float(f) => {
+            write_u8(buf, VALUE_TAG_FLOAT);
+            write_f64(buf, *f);
+        }
+        Value::Str(s) => {
+            write_u8(buf, VALUE_TAG_STR);
+            write_str(buf, s);
+        }
+        Value::Array(items) => {
+            write_u8(buf, VALUE_TAG_ARRAY);
+            write_u32(buf, items.len() as u32);
+            for item in items {
+                write_value_full(buf, item);
+            }
+        }
+    }
+}
+
+fn read_value_full(cur: &mut Cursor) -> Result<Value> {
+    match cur.read_u8()? {
+        VALUE_TAG_NULL => Ok(Value::Null),
+        VALUE_TAG_BOOL => Ok(Value::Bool(cur.read_u8()? != 0)),
+        VALUE_TAG_INT => Ok(Value::Int(cur.read_i64()?)),
+        VALUE_TAG_FLOAT => Ok(Value::Float(cur.read_f64()?)),
+        VALUE_TAG_STR => Ok(Value::Str(cur.read_str()?.to_string())),
+        VALUE_TAG_ARRAY => {
+            let n = cur.read_u32()? as usize;
+            let mut items = Vec::with_capacity(n);
+            for _ in 0..n {
+                items.push(read_value_full(cur)?);
+            }
+            Ok(Value::Array(items))
+        }
+        other => Err(Error::corruption(format!("segment docs: bad value tag {other}"))),
+    }
+}
+
+/// Write one field's value into its fixed-width directory slot, spilling
+/// variable-length content (`Str`/`Array`) into `strings`.
+fn encode_value_slot(slot: &mut [u8], value: &Value, strings: &mut Vec<u8>) {
+    debug_assert_eq!(slot.len(), VALUE_SLOT_LEN);
+    match value {
+        Value::Null => slot[0] = VALUE_TAG_NULL,
+        Value::Bool(b) => {
+            slot[0] = VALUE_TAG_BOOL;
+            slot[1] = *b as u8;
+        }
+        Value::Int(i) => {
+            slot[0] = VALUE_TAG_INT;
+            slot[1..9].copy_from_slice(&i.to_le_bytes());
+        }
+        Value::Float(f) => {
+            slot[0] = VALUE_TAG_FLOAT;
+            slot[1..9].copy_from_slice(&f.to_le_bytes());
+        }
+        Value::Str(_) | Value::Array(_) => {
+            slot[0] = if matches!(value, Value::Str(_)) { VALUE_TAG_STR } else { VALUE_TAG_ARRAY };
+            let mut encoded = Vec::new();
+            write_value_full(&mut encoded, value);
+            let offset = strings.len() as u32;
+            let length = encoded.len() as u32;
+            strings.extend_from_slice(&encoded);
+            slot[1..5].copy_from_slice(&offset.to_le_bytes());
+            slot[5..9].copy_from_slice(&length.to_le_bytes());
+        }
+    }
+}
+
+fn encode_docs(memtable: &MemTable, schema: &CollectionSchema) -> Vec<u8> {
+    let base = memtable.base();
+    let end = memtable.next_doc_id(); // exclusive
+    let len = (end - base) as usize;
+    let num_fields = schema.fields.len();
+
+    let mut presence = RoaringBitmap::new();
+    let mut field_lengths = vec![0u8; len * num_fields * 4];
+    let mut values_dir = vec![0u8; len * num_fields * VALUE_SLOT_LEN];
+    let mut strings = Vec::new();
+    let mut source_dir = vec![0u8; len * 8];
+    let mut source = Vec::new();
+
+    for (doc_id, doc) in memtable.iter() {
+        presence.insert(doc_id);
+        let idx = (doc_id - base) as usize;
+
+        for f in 0..num_fields {
+            let field_len = doc.field_lengths.get(f).copied().unwrap_or(0);
+            let fl_pos = idx * num_fields * 4 + f * 4;
+            field_lengths[fl_pos..fl_pos + 4].copy_from_slice(&field_len.to_le_bytes());
+
+            let value = doc.values.get(f).unwrap_or(&Value::Null);
+            let slot_pos = idx * num_fields * VALUE_SLOT_LEN + f * VALUE_SLOT_LEN;
+            encode_value_slot(&mut values_dir[slot_pos..slot_pos + VALUE_SLOT_LEN], value, &mut strings);
+        }
+
+        let source_bytes =
+            serde_json::to_vec(&doc.source).expect("an already-parsed document is valid JSON");
+        let offset = source.len() as u32;
+        let length = source_bytes.len() as u32;
+        source.extend_from_slice(&source_bytes);
+        let sd_pos = idx * 8;
+        source_dir[sd_pos..sd_pos + 4].copy_from_slice(&offset.to_le_bytes());
+        source_dir[sd_pos + 4..sd_pos + 8].copy_from_slice(&length.to_le_bytes());
+    }
+
+    let mut buf = Vec::new();
+    write_header(&mut buf, DOC_MAGIC);
+    write_u32(&mut buf, base);
+    write_u32(&mut buf, end);
+    write_u32(&mut buf, num_fields as u32);
+
+    let mut presence_bytes = Vec::new();
+    presence.serialize_into(&mut presence_bytes).expect("writing to a Vec cannot fail");
+    write_u32(&mut buf, presence_bytes.len() as u32);
+    buf.extend_from_slice(&presence_bytes);
+
+    write_u32(&mut buf, strings.len() as u32);
+    write_u32(&mut buf, source.len() as u32);
+
+    buf.extend_from_slice(&field_lengths);
+    buf.extend_from_slice(&values_dir);
+    buf.extend_from_slice(&source_dir);
+    buf.extend_from_slice(&strings);
+    buf.extend_from_slice(&source);
+
+    buf
+}
+
+/// The small, eager part of `.doc`: the doc-id range, field count, presence
+/// bitmap, and the byte offsets of each section. O(corpus / 8) for the
+/// presence bitmap (typically far less once roaring compresses a dense
+/// range); everything else here is O(1).
+pub(crate) struct DocHeader {
+    pub base: DocId,
+    pub end: DocId, // exclusive
+    pub num_fields: usize,
+    pub presence: RoaringBitmap,
+    field_lengths_start: usize,
+    values_dir_start: usize,
+    source_dir_start: usize,
+    strings_start: usize,
+    source_start: usize,
+}
+
+pub(crate) fn decode_doc_header(bytes: &[u8]) -> Result<DocHeader> {
+    let mut cur = Cursor::new(bytes, "segment doc store");
+    cur.read_header(DOC_MAGIC)?;
+    let base = cur.read_u32()?;
+    let end = cur.read_u32()?;
+    if end < base {
+        return Err(Error::corruption("segment doc store: end before base".to_string()));
+    }
+    let num_fields = cur.read_u32()? as usize;
+
+    let presence_len = cur.read_u32()? as usize;
+    let presence = RoaringBitmap::deserialize_from(cur.read_exact(presence_len)?)?;
+
+    let strings_len = cur.read_u32()? as usize;
+    let source_len = cur.read_u32()? as usize;
+
+    let len = (end - base) as usize;
+    let field_lengths_start = cur.position();
+    let values_dir_start = field_lengths_start + len * num_fields * 4;
+    let source_dir_start = values_dir_start + len * num_fields * VALUE_SLOT_LEN;
+    let strings_start = source_dir_start + len * 8;
+    let source_start = strings_start + strings_len;
+    let expected_end = source_start + source_len;
+    if expected_end > bytes.len() {
+        return Err(Error::corruption("segment doc store: sections run past end of file".to_string()));
+    }
+
+    Ok(DocHeader {
+        base,
+        end,
+        num_fields,
+        presence,
+        field_lengths_start,
+        values_dir_start,
+        source_dir_start,
+        strings_start,
+        source_start,
+    })
+}
+
+fn doc_index(header: &DocHeader, doc_id: DocId) -> Result<usize> {
+    doc_id
+        .checked_sub(header.base)
+        .filter(|&i| header.base + i < header.end)
+        .map(|i| i as usize)
+        .ok_or_else(|| Error::corruption("segment doc store: doc id out of range".to_string()))
+}
+
+/// BM25's `|d|`. Direct offset read, no decode, no allocation.
+pub(crate) fn field_len_at(bytes: &[u8], header: &DocHeader, doc_id: DocId, field: FieldId) -> Result<u32> {
+    let idx = doc_index(header, doc_id)?;
+    if field as usize >= header.num_fields {
+        return Ok(0);
+    }
+    let pos = header.field_lengths_start + idx * header.num_fields * 4 + field as usize * 4;
+    u32_at(bytes, pos, "segment doc store (field length)")
+}
+
+/// A document's value for one field. Zero-copy in spirit for `Null`/`Bool`/
+/// `Int`/`Float` — the returned `Value` owns nothing that wasn't already a
+/// stack value. `Str`/`Array` pay one decode of just that field's bytes.
+pub(crate) fn value_at(bytes: &[u8], header: &DocHeader, doc_id: DocId, field: FieldId) -> Result<Option<Value>> {
+    let idx = doc_index(header, doc_id)?;
+    if field as usize >= header.num_fields {
+        return Ok(None);
+    }
+    let pos = header.values_dir_start + idx * header.num_fields * VALUE_SLOT_LEN + field as usize * VALUE_SLOT_LEN;
+    let what = "segment doc store (value)";
+    let tag = u8_at(bytes, pos, what)?;
+    let value = match tag {
+        VALUE_TAG_NULL => Value::Null,
+        VALUE_TAG_BOOL => Value::Bool(bytes_at(bytes, pos + 1, 1, what)?[0] != 0),
+        VALUE_TAG_INT => Value::Int(i64_at(bytes, pos + 1, what)?),
+        VALUE_TAG_FLOAT => Value::Float(f64_at(bytes, pos + 1, what)?),
+        VALUE_TAG_STR | VALUE_TAG_ARRAY => {
+            let offset = u32_at(bytes, pos + 1, what)? as usize;
+            let length = u32_at(bytes, pos + 5, what)? as usize;
+            let slice = bytes_at(bytes, header.strings_start + offset, length, what)?;
+            let mut cur = Cursor::new(slice, what);
+            read_value_full(&mut cur)?
+        }
+        other => return Err(Error::corruption(format!("{what}: bad value tag {other}"))),
+    };
+    Ok(Some(value))
+}
+
+/// The document's verbatim source JSON — the one thing here that's actually
+/// expensive, paid only when a matched document becomes a returned hit.
+pub(crate) fn source_at(bytes: &[u8], header: &DocHeader, doc_id: DocId) -> Result<Option<Json>> {
+    let idx = doc_index(header, doc_id)?;
+    let what = "segment doc store (source)";
+    let pos = header.source_dir_start + idx * 8;
+    let offset = u32_at(bytes, pos, what)? as usize;
+    let length = u32_at(bytes, pos + 4, what)? as usize;
+    if length == 0 {
+        return Ok(None);
+    }
+    let slice = bytes_at(bytes, header.source_start + offset, length, what)?;
+    Ok(Some(serde_json::from_slice(slice)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tachyon_core::{FieldSchema, FieldType, ParsedDocument};
+
+    fn schema() -> CollectionSchema {
+        CollectionSchema::new(
+            "products",
+            vec![
+                FieldSchema::new("title", FieldType::Text).required(),
+                FieldSchema::new("tags", FieldType::Text),
+                FieldSchema::new("brand", FieldType::Keyword).with_facet(true),
+                FieldSchema::new("price", FieldType::Int).with_filter(true).with_sort(true),
+            ],
+        )
+    }
+
+    fn doc(id: &str, title: &str, tags: &[&str], brand: &str, price: i64) -> ParsedDocument {
+        ParsedDocument::parse(
+            json!({ "id": id, "title": title, "tags": tags, "brand": brand, "price": price }),
+            &schema(),
+        )
+        .unwrap()
+    }
+
+    /// A memtable with a live document, a replaced document, and a document
+    /// deleted before ever being flushed — the three cases a segment must
+    /// tell apart.
+    fn fixture() -> (MemTable, CollectionSchema) {
+        let schema = schema();
+        let mut m = MemTable::new(0, &schema);
+        m.insert(doc("1", "wireless mouse", &["red", "blue"], "Logitech", 2999));
+        m.insert(doc("2", "mouse pad", &["blue"], "Razer", 1999));
+        let hole = m.insert(doc("3", "keyboard", &[], "Logitech", 4999));
+        m.remove(hole);
+        (m, schema)
+    }
+
+    fn term_postings(
+        terms_bytes: &[u8],
+        post_bytes: &[u8],
+        term: &str,
+        field: FieldId,
+    ) -> Option<FieldPostings> {
+        let terms = validate_and_load_fst(terms_bytes, TERMS_MAGIC);
+        let term_id = terms.get(term)?;
+        let header = decode_post_header(post_bytes).unwrap();
+        let fields = decode_term_postings(post_bytes, &header, term_id).unwrap();
+        fields.into_iter().find(|(f, _)| *f == field).map(|(_, p)| p)
+    }
+
+    /// Load an `fst::Map` straight from an in-memory encoded blob, skipping
+    /// the file/mmap step — used only by tests that don't need real files.
+    fn validate_and_load_fst(bytes: &[u8], magic: &[u8; 8]) -> fst::Map<Vec<u8>> {
+        let start = validate_header(bytes, magic, "test fst").unwrap();
+        fst::Map::new(bytes[start..].to_vec()).unwrap()
+    }
+
+    #[test]
+    fn holes_are_excluded_from_every_blob() {
+        let (m, schema) = fixture();
+        let encoded = encode(&m, &schema).unwrap();
+
+        let terms = validate_and_load_fst(&encoded.terms, TERMS_MAGIC);
+        assert!(terms.get("keyboard").is_none(), "a term only the hole used must not survive");
+        assert!(terms.get("mouse").is_some());
+
+        let ids = validate_and_load_fst(&encoded.ids, IDS_MAGIC);
+        assert!(ids.get("3").is_none(), "the hole's id must not resolve");
+        assert_eq!(ids.get("1"), Some(0));
+
+        let col_header = decode_col_header(&encoded.col).unwrap();
+        let brand = decode_keyword_column(&encoded.col, &col_header, 2).unwrap().unwrap();
+        assert_eq!(brand.equals("Logitech").iter().collect::<Vec<_>>(), vec![0]);
+
+        let price = decode_numeric_column(&encoded.col, &col_header, 3).unwrap().unwrap();
+        assert!(
+            price.range(Some(NumKey::Int(4999)), Some(NumKey::Int(4999))).is_empty(),
+            "doc 3's price (4999) must not survive"
+        );
+
+        let doc_header = decode_doc_header(&encoded.doc).unwrap();
+        assert!(!doc_header.presence.contains(2), "the hole must be absent, not a live doc");
+        assert!(source_at(&encoded.doc, &doc_header, 2).unwrap().is_none());
+    }
+
+    #[test]
+    fn postings_match_positions_and_are_grouped_by_field() {
+        let (m, schema) = fixture();
+        let encoded = encode(&m, &schema).unwrap();
+
+        // "mouse" occurs in title (field 0) of docs 0 and 1.
+        let mouse = term_postings(&encoded.terms, &encoded.post, "mouse", 0).unwrap();
+        assert_eq!(mouse.docs.iter().map(|d| d.doc_id).collect::<Vec<_>>(), vec![0, 1]);
+        assert_eq!(mouse.docs[0].positions, vec![1], "\"wireless mouse\": mouse is token 1");
+        assert_eq!(mouse.docs[1].positions, vec![0], "\"mouse pad\": mouse is token 0");
+
+        // "blue" is a multi-valued tag (field 1) shared by both live docs.
+        let blue = term_postings(&encoded.terms, &encoded.post, "blue", 1).unwrap();
+        assert_eq!(blue.docs.iter().map(|d| d.doc_id).collect::<Vec<_>>(), vec![0, 1]);
+        assert_eq!(blue.docs[0].positions, vec![1 + crate::memtable::MULTI_VALUE_POSITION_GAP]);
+
+        assert!(term_postings(&encoded.terms, &encoded.post, "keyboard", 0).is_none());
+    }
+
+    #[test]
+    fn lean_doc_id_decode_matches_the_full_postings_decode_minus_positions() {
+        let (m, schema) = fixture();
+        let encoded = encode(&m, &schema).unwrap();
+        let terms = validate_and_load_fst(&encoded.terms, TERMS_MAGIC);
+        let header = decode_post_header(&encoded.post).unwrap();
+
+        for (term, field) in [("mouse", 0u16), ("blue", 1), ("pad", 0)] {
+            let term_id = terms.get(term).unwrap();
+            let full = decode_term_postings(&encoded.post, &header, term_id).unwrap();
+            let expected: Vec<DocId> = full
+                .into_iter()
+                .find(|(f, _)| *f == field)
+                .map(|(_, p)| p.docs.iter().map(|d| d.doc_id).collect())
+                .unwrap_or_default();
+
+            let lean = decode_term_field_doc_ids(&encoded.post, &header, term_id, field).unwrap();
+            assert_eq!(lean, expected, "term {term:?} field {field}");
+        }
+
+        // A field the term never occurs in comes back empty, not an error.
+        let mouse_id = terms.get("mouse").unwrap();
+        assert!(decode_term_field_doc_ids(&encoded.post, &header, mouse_id, 3).unwrap().is_empty());
+    }
+
+    #[test]
+    fn field_stats_count_only_live_documents() {
+        let (m, schema) = fixture();
+        let encoded = encode(&m, &schema).unwrap();
+        let header = decode_post_header(&encoded.post).unwrap();
+
+        // title (field 0): "wireless mouse" (2 tokens) + "mouse pad" (2
+        // tokens); the hole's "keyboard" (1 token) must not count.
+        assert_eq!(header.field_doc_count[0], 2);
+        assert_eq!(header.field_total_len[0], 4);
+    }
+
+    #[test]
+    fn columns_round_trip_numeric_and_keyword() {
+        let (m, schema) = fixture();
+        let encoded = encode(&m, &schema).unwrap();
+        let header = decode_col_header(&encoded.col).unwrap();
+
+        let price = decode_numeric_column(&encoded.col, &header, 3).unwrap().unwrap();
+        assert_eq!(price.range(Some(NumKey::Int(1999)), Some(NumKey::Int(2999))).len(), 2);
+
+        let brand = decode_keyword_column(&encoded.col, &header, 2).unwrap().unwrap();
+        assert_eq!(brand.equals("Logitech").iter().collect::<Vec<_>>(), vec![0]);
+        assert_eq!(brand.equals("Razer").iter().collect::<Vec<_>>(), vec![1]);
+        assert_eq!(brand.num_values(), 2, "the hole's Logitech must not add a phantom value");
+
+        // A field the schema gives no column at all.
+        assert!(decode_numeric_column(&encoded.col, &header, 0).unwrap().is_none());
+        assert!(decode_keyword_column(&encoded.col, &header, 0).unwrap().is_none());
+    }
+
+    #[test]
+    fn doc_store_round_trips_source_values_and_lengths() {
+        let (m, schema) = fixture();
+        let original = m.get(0).unwrap().clone();
+        let encoded = encode(&m, &schema).unwrap();
+        let header = decode_doc_header(&encoded.doc).unwrap();
+
+        let source = source_at(&encoded.doc, &header, 0).unwrap().unwrap();
+        assert_eq!(source, original.source);
+
+        for (field, expected) in original.values.iter().enumerate() {
+            let got = value_at(&encoded.doc, &header, 0, field as FieldId).unwrap().unwrap();
+            assert_eq!(&got, expected, "field {field}");
+        }
+        for (field, &expected_len) in original.field_lengths.iter().enumerate() {
+            let got = field_len_at(&encoded.doc, &header, 0, field as FieldId).unwrap();
+            assert_eq!(got, expected_len, "field {field}");
+        }
+
+        let ids = validate_and_load_fst(&encoded.ids, IDS_MAGIC);
+        assert_eq!(ids.get("1"), Some(0));
+    }
+
+    #[test]
+    fn multi_valued_and_scalar_values_round_trip_through_the_fixed_slot() {
+        let schema = CollectionSchema::new(
+            "things",
+            vec![
+                FieldSchema::new("title", FieldType::Text),
+                FieldSchema::new("tags", FieldType::Keyword),
+                FieldSchema::new("count", FieldType::Int),
+                FieldSchema::new("score", FieldType::Float),
+                FieldSchema::new("active", FieldType::Bool),
+            ],
+        );
+        let mut m = MemTable::new(0, &schema);
+        let raw = json!({
+            "id": "1", "title": "thing", "tags": ["a", "b", "c"],
+            "count": 42, "score": 3.5, "active": true,
+        });
+        m.insert(ParsedDocument::parse(raw, &schema).unwrap());
+
+        let encoded = encode(&m, &schema).unwrap();
+        let header = decode_doc_header(&encoded.doc).unwrap();
+
+        assert_eq!(
+            value_at(&encoded.doc, &header, 0, 1).unwrap().unwrap(),
+            Value::Array(vec![Value::Str("a".into()), Value::Str("b".into()), Value::Str("c".into())])
+        );
+        assert_eq!(value_at(&encoded.doc, &header, 0, 2).unwrap().unwrap(), Value::Int(42));
+        assert_eq!(value_at(&encoded.doc, &header, 0, 3).unwrap().unwrap(), Value::Float(3.5));
+        assert_eq!(value_at(&encoded.doc, &header, 0, 4).unwrap().unwrap(), Value::Bool(true));
+    }
+
+    #[test]
+    fn an_all_deleted_memtable_still_encodes_a_valid_empty_segment() {
+        let schema = schema();
+        let mut m = MemTable::new(0, &schema);
+        let a = m.insert(doc("1", "one", &[], "X", 1));
+        let b = m.insert(doc("2", "two", &[], "Y", 2));
+        m.remove(a);
+        m.remove(b);
+        assert_eq!(m.next_doc_id(), m.base() + 2, "ids were allocated even though none are live");
+
+        let encoded = encode(&m, &schema).unwrap();
+        let terms = validate_and_load_fst(&encoded.terms, TERMS_MAGIC);
+        assert!(terms.get("one").is_none());
+
+        let post_header = decode_post_header(&encoded.post).unwrap();
+        assert!(post_header.offsets.is_empty());
+
+        let doc_header = decode_doc_header(&encoded.doc).unwrap();
+        assert_eq!(doc_header.base, 0);
+        assert_eq!(doc_header.end, 2);
+        assert!(doc_header.presence.is_empty());
+    }
+
+    #[test]
+    fn corrupt_headers_are_rejected_not_panicked() {
+        let (m, schema) = fixture();
+        let encoded = encode(&m, &schema).unwrap();
+
+        let mut bad_terms = encoded.terms.clone();
+        bad_terms[0] ^= 0xff;
+        assert!(validate_header(&bad_terms, TERMS_MAGIC, "test").is_err());
+
+        let mut bad_post = encoded.post.clone();
+        bad_post[0] ^= 0xff;
+        assert!(decode_post_header(&bad_post).is_err());
+
+        let mut bad_col = encoded.col.clone();
+        bad_col[0] ^= 0xff;
+        assert!(decode_col_header(&bad_col).is_err());
+
+        let mut bad_doc = encoded.doc.clone();
+        bad_doc[0] ^= 0xff;
+        assert!(decode_doc_header(&bad_doc).is_err());
+
+        // Truncated mid-section, not just a bad header.
+        let truncated = &encoded.doc[..encoded.doc.len() - 3];
+        assert!(decode_doc_header(truncated).is_err());
+
+        let version_mismatch = {
+            let mut b = encoded.doc.clone();
+            b[8..12].copy_from_slice(&999u32.to_le_bytes());
+            b
+        };
+        assert!(decode_doc_header(&version_mismatch).is_err());
+    }
+
+    #[test]
+    fn prefix_scan_over_the_fst_matches_the_memtable() {
+        let (m, schema) = fixture();
+        let encoded = encode(&m, &schema).unwrap();
+        let terms = validate_and_load_fst(&encoded.terms, TERMS_MAGIC);
+
+        use fst::{Automaton, IntoStreamer, Streamer};
+        let mut found = Vec::new();
+        let mut stream = terms.search(fst::automaton::Str::new("mo").starts_with()).into_stream();
+        while let Some((t, _)) = stream.next() {
+            found.push(std::str::from_utf8(t).unwrap().to_owned());
+        }
+        let mut expected: Vec<String> =
+            m.index().terms_with_prefix("mo").map(str::to_owned).collect();
+        found.sort();
+        expected.sort();
+        assert_eq!(found, expected);
+    }
+}

--- a/crates/tachyon-index/src/segment/format.rs
+++ b/crates/tachyon-index/src/segment/format.rs
@@ -1,0 +1,186 @@
+//! Shared segment file primitives: the format version, per-file magic
+//! headers, and the small bounds-checked binary cursor `.post`/`.col`/`.doc`
+//! are read through. `.terms` is an [`fst::Map`] wrapped in the same header;
+//! `fst` manages the bytes after it.
+//!
+//! Bump [`SEGMENT_FORMAT_VERSION`] whenever the byte layout changes, or
+//! whenever the tokenizer changes — see `tokenizer.rs`'s warning that a
+//! tokenizer change invalidates existing segments.
+
+use tachyon_core::{Error, Result};
+
+/// v2: postings, columns, and the document store are read lazily from mmap'd
+/// files via offset tables instead of being fully decoded at open time. v1
+/// segments are not readable by this build — same policy as a tokenizer
+/// change, which also invalidates existing segments.
+pub const SEGMENT_FORMAT_VERSION: u32 = 2;
+
+/// Byte length of every segment file's header (8-byte magic + 4-byte version).
+pub const HEADER_LEN: usize = 12;
+
+pub const TERMS_MAGIC: &[u8; 8] = b"TCHYTRM\0";
+pub const IDS_MAGIC: &[u8; 8] = b"TCHYIDS\0";
+pub const POST_MAGIC: &[u8; 8] = b"TCHYPST\0";
+pub const COL_MAGIC: &[u8; 8] = b"TCHYCOL\0";
+pub const DOC_MAGIC: &[u8; 8] = b"TCHYDOC\0";
+
+pub fn write_header(buf: &mut Vec<u8>, magic: &[u8; 8]) {
+    buf.extend_from_slice(magic);
+    buf.extend_from_slice(&SEGMENT_FORMAT_VERSION.to_le_bytes());
+}
+
+pub fn write_u8(buf: &mut Vec<u8>, v: u8) {
+    buf.push(v);
+}
+pub fn write_u32(buf: &mut Vec<u8>, v: u32) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+pub fn write_u64(buf: &mut Vec<u8>, v: u64) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+pub fn write_i64(buf: &mut Vec<u8>, v: i64) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+pub fn write_f64(buf: &mut Vec<u8>, v: f64) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+pub fn write_bytes(buf: &mut Vec<u8>, bytes: &[u8]) {
+    write_u32(buf, bytes.len() as u32);
+    buf.extend_from_slice(bytes);
+}
+pub fn write_str(buf: &mut Vec<u8>, s: &str) {
+    write_bytes(buf, s.as_bytes());
+}
+
+/// A read cursor over a decoded segment blob, with bounds-checked primitives.
+/// A read past the end, or a header mismatch, is [`Error::corruption`] —
+/// never a panic, since these bytes come from disk and may be truncated or
+/// tampered with.
+pub struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+    what: &'static str,
+}
+
+impl<'a> Cursor<'a> {
+    pub fn new(bytes: &'a [u8], what: &'static str) -> Cursor<'a> {
+        Cursor { bytes, pos: 0, what }
+    }
+
+    /// Byte offset consumed so far, e.g. to find where a header-prefixed
+    /// sub-format (like the `.terms` file's `fst::Map` payload) begins.
+    pub fn position(&self) -> usize {
+        self.pos
+    }
+
+    fn err(&self) -> Error {
+        Error::corruption(format!("{}: truncated or malformed", self.what))
+    }
+
+    pub fn read_header(&mut self, magic: &[u8; 8]) -> Result<()> {
+        let got = self.take(8)?;
+        if got != &magic[..] {
+            return Err(Error::corruption(format!("{}: not a Tachyon segment file", self.what)));
+        }
+        let version = self.read_u32()?;
+        if version != SEGMENT_FORMAT_VERSION {
+            return Err(Error::corruption(format!(
+                "{}: segment format version {version}, this build understands \
+                 {SEGMENT_FORMAT_VERSION}",
+                self.what
+            )));
+        }
+        Ok(())
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8]> {
+        let end = self.pos.checked_add(n).ok_or_else(|| self.err())?;
+        if end > self.bytes.len() {
+            return Err(self.err());
+        }
+        let slice = &self.bytes[self.pos..end];
+        self.pos = end;
+        Ok(slice)
+    }
+
+    pub fn read_u8(&mut self) -> Result<u8> {
+        Ok(self.take(1)?[0])
+    }
+
+    pub fn read_u32(&mut self) -> Result<u32> {
+        Ok(u32::from_le_bytes(self.take(4)?.try_into().expect("4 bytes")))
+    }
+
+    pub fn read_u64(&mut self) -> Result<u64> {
+        Ok(u64::from_le_bytes(self.take(8)?.try_into().expect("8 bytes")))
+    }
+
+    pub fn read_i64(&mut self) -> Result<i64> {
+        Ok(i64::from_le_bytes(self.take(8)?.try_into().expect("8 bytes")))
+    }
+
+    pub fn read_f64(&mut self) -> Result<f64> {
+        Ok(f64::from_le_bytes(self.take(8)?.try_into().expect("8 bytes")))
+    }
+
+    /// A length-prefixed byte string.
+    pub fn read_bytes(&mut self) -> Result<&'a [u8]> {
+        let len = self.read_u32()? as usize;
+        self.take(len)
+    }
+
+    pub fn read_str(&mut self) -> Result<&'a str> {
+        std::str::from_utf8(self.read_bytes()?).map_err(|_| self.err())
+    }
+
+    /// Exactly `n` bytes, with no length prefix of their own — for a length
+    /// already known from elsewhere (e.g. a field read just before this one).
+    pub fn read_exact(&mut self, n: usize) -> Result<&'a [u8]> {
+        self.take(n)
+    }
+
+    /// Advance past `n` bytes without reading them — for skipping data a
+    /// caller doesn't need (e.g. positions, when only a document count is
+    /// wanted) without paying to decode and allocate it.
+    pub fn skip(&mut self, n: usize) -> Result<()> {
+        self.take(n).map(|_| ())
+    }
+}
+
+// --- direct-offset access -------------------------------------------------
+//
+// Used for the fixed-width sections of `.doc` (`field_lengths`, `values_dir`)
+// that are addressed directly by `doc_id`/`field` arithmetic rather than
+// walked sequentially — no `Cursor`, no decode step, just a bounds-checked
+// read at a computed byte offset. This is what makes `field_len` and a
+// numeric/bool `value` genuinely zero-copy: the mmap'd page is touched, but
+// nothing is parsed or allocated.
+
+fn slice_at<'a>(bytes: &'a [u8], offset: usize, len: usize, what: &'static str) -> Result<&'a [u8]> {
+    let end = offset
+        .checked_add(len)
+        .ok_or_else(|| Error::corruption(format!("{what}: offset overflow")))?;
+    bytes
+        .get(offset..end)
+        .ok_or_else(|| Error::corruption(format!("{what}: offset out of range")))
+}
+
+pub fn u8_at(bytes: &[u8], offset: usize, what: &'static str) -> Result<u8> {
+    Ok(slice_at(bytes, offset, 1, what)?[0])
+}
+
+pub fn u32_at(bytes: &[u8], offset: usize, what: &'static str) -> Result<u32> {
+    Ok(u32::from_le_bytes(slice_at(bytes, offset, 4, what)?.try_into().expect("4 bytes")))
+}
+
+pub fn i64_at(bytes: &[u8], offset: usize, what: &'static str) -> Result<i64> {
+    Ok(i64::from_le_bytes(slice_at(bytes, offset, 8, what)?.try_into().expect("8 bytes")))
+}
+
+pub fn f64_at(bytes: &[u8], offset: usize, what: &'static str) -> Result<f64> {
+    Ok(f64::from_le_bytes(slice_at(bytes, offset, 8, what)?.try_into().expect("8 bytes")))
+}
+
+pub fn bytes_at<'a>(bytes: &'a [u8], offset: usize, len: usize, what: &'static str) -> Result<&'a [u8]> {
+    slice_at(bytes, offset, len, what)
+}

--- a/crates/tachyon-index/src/segment/mod.rs
+++ b/crates/tachyon-index/src/segment/mod.rs
@@ -1,0 +1,17 @@
+//! On-disk segments: encode a flushed [`MemTable`](crate::memtable::MemTable)
+//! into immutable segment files, and read them back — lazily — into an
+//! [`IndexSource`].
+//!
+//! Five files per segment id (`.terms`, `.ids`, `.post`, `.col`, `.doc`)
+//! under the `segments/<id>.<ext>` convention `tachyon-storage::Layout`
+//! already provides. Writing the bytes to disk and committing them into
+//! `state.json` is `tachyon-engine`'s job — [`codec`] only turns a memtable
+//! into bytes and back; [`reader`] is what maps those bytes into memory and
+//! decodes them on demand.
+
+mod codec;
+mod format;
+mod reader;
+
+pub use codec::{encode, EncodedSegment};
+pub use reader::{SegmentFilePaths, SegmentReader};

--- a/crates/tachyon-index/src/segment/reader.rs
+++ b/crates/tachyon-index/src/segment/reader.rs
@@ -1,0 +1,488 @@
+//! Reads an on-disk segment back into query-able structures, behind
+//! [`IndexSource`] — the same interface [`MemTable`](crate::memtable::MemTable)
+//! implements, so the executor never needs to know which one it is holding.
+//!
+//! Everything here is mmap'd, and everything decodes lazily: opening a
+//! segment costs O(number of terms) + O(number of fields) + O(corpus size /
+//! 8) for the presence bitmap — never O(corpus size × document size). A
+//! query pays only for the postings, columns, and document values it
+//! actually touches, decoded fresh from the mapped pages each time and never
+//! retained. See `codec.rs`'s module doc for the on-disk layout this reads.
+
+use std::borrow::Cow;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use memmap2::{Mmap, MmapOptions};
+use roaring::RoaringBitmap;
+use serde_json::Value as Json;
+use tachyon_core::{CollectionSchema, DocId, Error, FieldId, Result, Value};
+
+use crate::columns::{KeywordColumn, NumericColumn};
+use crate::fuzzy::FuzzyMatcher;
+use crate::inverted::FieldPostings;
+use crate::source::IndexSource;
+
+use super::codec::{self, ColHeader, DocHeader, PostHeader};
+use super::format::{HEADER_LEN, IDS_MAGIC, TERMS_MAGIC};
+
+/// The five files one segment is stored as.
+#[derive(Debug, Clone)]
+pub struct SegmentFilePaths {
+    pub terms: PathBuf,
+    pub ids: PathBuf,
+    pub post: PathBuf,
+    pub col: PathBuf,
+    pub doc: PathBuf,
+}
+
+pub struct SegmentReader {
+    terms: fst::Map<Mmap>,
+    ids: fst::Map<Mmap>,
+    post: Mmap,
+    post_header: PostHeader,
+    col: Mmap,
+    col_header: ColHeader,
+    doc: Mmap,
+    doc_header: DocHeader,
+}
+
+/// Map a whole file. Used for `.post`/`.col`/`.doc`, whose own headers (read
+/// by `codec::decode_*_header`) start at byte 0.
+///
+/// # Safety
+///
+/// `Mmap::map` is unsafe because another process mutating or truncating the
+/// file while it's mapped is undefined behavior. Segment files never are:
+/// they're written once via `write_atomic` (temp file, then rename) and a
+/// given segment id is only opened after `state.json` commits it — nothing
+/// in Tachyon's commit protocol ever rewrites a file in place once a reader
+/// might be mapping it, in this process or any other, since `Collection::open`
+/// only ever names ids `state.json` already lists.
+fn open_mmap(path: &Path) -> Result<Mmap> {
+    let file = File::open(path)?;
+    unsafe { Mmap::map(&file) }.map_err(Error::from)
+}
+
+/// Map an `fst::Map`'s file starting just past its header, so the FST sees
+/// nothing but its own bytes — `fst::Map::new` requires that.
+fn open_fst(path: &Path, magic: &[u8; 8]) -> Result<fst::Map<Mmap>> {
+    let mut file = File::open(path)?;
+    let mut header = [0u8; HEADER_LEN];
+    file.read_exact(&mut header)
+        .map_err(|e| Error::corruption(format!("{}: {e}", path.display())))?;
+    codec::validate_header(&header, magic, "segment fst")?;
+
+    // SAFETY: see `open_mmap` — the same immutability guarantee applies.
+    let payload = unsafe { MmapOptions::new().offset(HEADER_LEN as u64).map(&file) }?;
+    fst::Map::new(payload).map_err(|e| Error::corruption(format!("{}: {e}", path.display())))
+}
+
+impl SegmentReader {
+    /// Open and validate all five files. Actual I/O and mmap'ing happen only
+    /// here; every other method just reads from the pages already mapped.
+    pub fn open(paths: &SegmentFilePaths, schema: &CollectionSchema) -> Result<SegmentReader> {
+        let terms = open_fst(&paths.terms, TERMS_MAGIC)?;
+        let ids = open_fst(&paths.ids, IDS_MAGIC)?;
+
+        let post = open_mmap(&paths.post)?;
+        let post_header = codec::decode_post_header(&post)?;
+
+        let col = open_mmap(&paths.col)?;
+        let col_header = codec::decode_col_header(&col)?;
+
+        let doc = open_mmap(&paths.doc)?;
+        let doc_header = codec::decode_doc_header(&doc)?;
+
+        if post_header.field_doc_count.len() != schema.fields.len() {
+            return Err(Error::corruption(format!(
+                "segment at {}: field count does not match the collection schema",
+                paths.doc.display()
+            )));
+        }
+
+        Ok(SegmentReader { terms, ids, post, post_header, col, col_header, doc, doc_header })
+    }
+
+    /// Segment-local id resolution, mirroring `MemTable::lookup`. Not part of
+    /// [`IndexSource`], which has no string-id concept — `Collection` calls
+    /// this directly on the concrete type.
+    pub fn lookup_id(&self, id: &str) -> Option<DocId> {
+        self.terms_get(&self.ids, id)
+    }
+
+    fn terms_get(&self, map: &fst::Map<Mmap>, key: &str) -> Option<DocId> {
+        map.get(key).map(|v| v as DocId)
+    }
+
+    /// Segment-local full document fetch, mirroring `MemTable::get`. Owned,
+    /// not borrowed: the source JSON is parsed fresh from the mapped bytes on
+    /// every call rather than held decoded between calls.
+    pub fn get(&self, doc_id: DocId) -> Option<Json> {
+        if !self.doc_header.presence.contains(doc_id) {
+            return None;
+        }
+        match codec::source_at(&self.doc, &self.doc_header, doc_id) {
+            Ok(source) => source,
+            Err(e) => {
+                tracing::warn!(doc_id, error = %e, "segment: failed to decode document source");
+                None
+            }
+        }
+    }
+}
+
+impl IndexSource for SegmentReader {
+    fn min_doc_id(&self) -> DocId {
+        self.doc_header.base
+    }
+
+    fn end_doc_id(&self) -> DocId {
+        self.doc_header.end
+    }
+
+    fn value(&self, doc_id: DocId, field: FieldId) -> Option<Cow<'_, Value>> {
+        if !self.doc_header.presence.contains(doc_id) {
+            return None;
+        }
+        match codec::value_at(&self.doc, &self.doc_header, doc_id, field) {
+            Ok(v) => v.map(Cow::Owned),
+            Err(e) => {
+                tracing::warn!(doc_id, field, error = %e, "segment: failed to decode value");
+                None
+            }
+        }
+    }
+
+    fn numeric_column(&self, field: FieldId) -> Option<Cow<'_, NumericColumn>> {
+        match codec::decode_numeric_column(&self.col, &self.col_header, field) {
+            Ok(col) => col.map(Cow::Owned),
+            Err(e) => {
+                tracing::warn!(field, error = %e, "segment: failed to decode numeric column");
+                None
+            }
+        }
+    }
+
+    fn keyword_column(&self, field: FieldId) -> Option<Cow<'_, KeywordColumn>> {
+        match codec::decode_keyword_column(&self.col, &self.col_header, field) {
+            Ok(col) => col.map(Cow::Owned),
+            Err(e) => {
+                tracing::warn!(field, error = %e, "segment: failed to decode keyword column");
+                None
+            }
+        }
+    }
+
+    fn postings(&self, term: &str, field: FieldId) -> Option<Cow<'_, FieldPostings>> {
+        let term_id = self.terms.get(term)?;
+        match codec::decode_term_postings(&self.post, &self.post_header, term_id) {
+            Ok(fields) => fields.into_iter().find(|(f, _)| *f == field).map(|(_, p)| Cow::Owned(p)),
+            Err(e) => {
+                tracing::warn!(term, field, error = %e, "segment: failed to decode postings");
+                None
+            }
+        }
+    }
+
+    // Overridden rather than left to the trait's default (which goes through
+    // `postings()`): both only ever need doc ids, never positions, and
+    // autocomplete calls these across every candidate term and every source.
+    // Decoding — and allocating — full posting lists including positions just
+    // to count them would make the cheap common case pay for data nobody
+    // asked for.
+
+    fn doc_freq(&self, term: &str, field: FieldId) -> u32 {
+        let Some(term_id) = self.terms.get(term) else { return 0 };
+        match codec::decode_term_field_doc_ids(&self.post, &self.post_header, term_id, field) {
+            Ok(doc_ids) => doc_ids.len() as u32,
+            Err(e) => {
+                tracing::warn!(term, field, error = %e, "segment: failed to decode doc ids");
+                0
+            }
+        }
+    }
+
+    fn live_doc_freq(&self, term: &str, field: FieldId, deleted: &RoaringBitmap) -> u64 {
+        let Some(term_id) = self.terms.get(term) else { return 0 };
+        match codec::decode_term_field_doc_ids(&self.post, &self.post_header, term_id, field) {
+            Ok(doc_ids) => doc_ids
+                .into_iter()
+                .filter(|&doc_id| self.is_live(doc_id) && !deleted.contains(doc_id))
+                .count() as u64,
+            Err(e) => {
+                tracing::warn!(term, field, error = %e, "segment: failed to decode doc ids");
+                0
+            }
+        }
+    }
+
+    fn field_doc_count(&self, field: FieldId) -> u32 {
+        self.post_header.field_doc_count.get(field as usize).copied().unwrap_or(0)
+    }
+
+    fn total_field_len(&self, field: FieldId) -> u64 {
+        self.post_header.field_total_len.get(field as usize).copied().unwrap_or(0)
+    }
+
+    fn field_len(&self, doc_id: DocId, field: FieldId) -> u32 {
+        if !self.doc_header.presence.contains(doc_id) {
+            return 0;
+        }
+        match codec::field_len_at(&self.doc, &self.doc_header, doc_id, field) {
+            Ok(len) => len,
+            Err(e) => {
+                tracing::warn!(doc_id, field, error = %e, "segment: failed to read field length");
+                0
+            }
+        }
+    }
+
+    fn is_live(&self, doc_id: DocId) -> bool {
+        self.doc_header.presence.contains(doc_id)
+    }
+
+    fn collect_terms_with_prefix(&self, prefix: &str, limit: usize, out: &mut Vec<String>) {
+        use fst::automaton::Str;
+        use fst::{Automaton, IntoStreamer, Streamer};
+
+        let matcher = Str::new(prefix).starts_with();
+        let mut stream = self.terms.search(matcher).into_stream();
+        while out.len() < limit {
+            let Some((term, _)) = stream.next() else { break };
+            if let Ok(s) = std::str::from_utf8(term) {
+                out.push(s.to_owned());
+            }
+        }
+    }
+
+    fn collect_fuzzy_terms(&self, matcher: &mut FuzzyMatcher, out: &mut Vec<(String, u32)>) {
+        use fst::Streamer;
+
+        // A linear scan over the sorted dictionary, same as `MemTable`'s own
+        // `collect_fuzzy_terms` — a smarter Levenshtein-automaton
+        // intersection with the FST is future work, not required for
+        // correctness.
+        let mut stream = self.terms.stream();
+        while let Some((term, _)) = stream.next() {
+            let Ok(s) = std::str::from_utf8(term) else { continue };
+            if let Some(distance) = matcher.distance(s) {
+                out.push((s.to_owned(), distance));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tachyon_core::{FieldSchema, FieldType, ParsedDocument};
+
+    use crate::columns::NumKey;
+    use crate::fuzzy::FuzzyMatcher;
+    use crate::memtable::MemTable;
+
+    fn schema() -> CollectionSchema {
+        CollectionSchema::new(
+            "products",
+            vec![
+                FieldSchema::new("title", FieldType::Text).required(),
+                FieldSchema::new("tags", FieldType::Text),
+                FieldSchema::new("brand", FieldType::Keyword).with_facet(true),
+                FieldSchema::new("price", FieldType::Int).with_filter(true).with_sort(true),
+            ],
+        )
+    }
+
+    fn doc(id: &str, title: &str, tags: &[&str], brand: &str, price: i64) -> ParsedDocument {
+        ParsedDocument::parse(
+            json!({ "id": id, "title": title, "tags": tags, "brand": brand, "price": price }),
+            &schema(),
+        )
+        .unwrap()
+    }
+
+    /// The hole reuses "mouse" rather than a unique term, so the surface this
+    /// test compares (live terms, prefix scans, fuzzy scans) doesn't hit the
+    /// separately-tested "a hole-only term disappears entirely" case.
+    fn fixture() -> (MemTable, CollectionSchema) {
+        let schema = schema();
+        let mut m = MemTable::new(0, &schema);
+        m.insert(doc("1", "wireless mouse", &["red", "blue"], "Logitech", 2999));
+        m.insert(doc("2", "mouse pad", &["blue"], "Razer", 1999));
+        let hole = m.insert(doc("3", "mouse", &[], "Logitech", 4999));
+        m.remove(hole);
+        (m, schema)
+    }
+
+    fn write_segment(dir: &Path, encoded: &super::super::EncodedSegment) -> SegmentFilePaths {
+        let paths = SegmentFilePaths {
+            terms: dir.join("0000000001.terms"),
+            ids: dir.join("0000000001.ids"),
+            post: dir.join("0000000001.post"),
+            col: dir.join("0000000001.col"),
+            doc: dir.join("0000000001.doc"),
+        };
+        std::fs::write(&paths.terms, &encoded.terms).unwrap();
+        std::fs::write(&paths.ids, &encoded.ids).unwrap();
+        std::fs::write(&paths.post, &encoded.post).unwrap();
+        std::fs::write(&paths.col, &encoded.col).unwrap();
+        std::fs::write(&paths.doc, &encoded.doc).unwrap();
+        paths
+    }
+
+    #[test]
+    fn index_source_answers_agree_with_the_memtable_it_was_built_from() {
+        let (m, schema) = fixture();
+        let dir = tempfile::tempdir().unwrap();
+        let encoded = super::super::encode(&m, &schema).unwrap();
+        let paths = write_segment(dir.path(), &encoded);
+        let reader = SegmentReader::open(&paths, &schema).unwrap();
+
+        let mem: &dyn IndexSource = &m;
+        let seg: &dyn IndexSource = &reader;
+
+        assert_eq!(mem.min_doc_id(), seg.min_doc_id());
+        assert_eq!(mem.end_doc_id(), seg.end_doc_id());
+
+        for doc_id in mem.min_doc_id()..mem.end_doc_id() {
+            assert_eq!(mem.is_live(doc_id), seg.is_live(doc_id), "doc {doc_id}");
+            for field in 0..schema.fields.len() as FieldId {
+                assert_eq!(
+                    mem.value(doc_id, field).as_deref(),
+                    seg.value(doc_id, field).as_deref(),
+                    "doc {doc_id} field {field}"
+                );
+                assert_eq!(
+                    mem.field_len(doc_id, field),
+                    seg.field_len(doc_id, field),
+                    "doc {doc_id} field {field}"
+                );
+            }
+        }
+
+        for term in ["mouse", "wireless", "pad", "blue", "red", "keyboard", "nope"] {
+            for field in [0u16, 1] {
+                // The memtable's postings still carry the hole until a
+                // flush; a segment never does. Filter to what the memtable
+                // itself considers live before comparing.
+                let mem_docs: Option<Vec<(u32, Vec<u32>)>> = mem.postings(term, field).map(|p| {
+                    p.docs
+                        .iter()
+                        .filter(|d| mem.is_live(d.doc_id))
+                        .map(|d| (d.doc_id, d.positions.clone()))
+                        .collect()
+                });
+                let mem_docs = mem_docs.filter(|d| !d.is_empty());
+                let seg_docs: Option<Vec<(u32, Vec<u32>)>> = seg
+                    .postings(term, field)
+                    .map(|p| p.docs.iter().map(|d| (d.doc_id, d.positions.clone())).collect());
+                assert_eq!(mem_docs, seg_docs, "term {term:?} field {field}");
+
+                // doc_freq/live_doc_freq go through a separate, positions-free
+                // decode path in the segment (see reader.rs's override) —
+                // exercise it against the same live-only expectation.
+                let expected_live_freq = mem_docs.as_ref().map_or(0, |d| d.len() as u64);
+                assert_eq!(
+                    seg.live_doc_freq(term, field, &RoaringBitmap::new()),
+                    expected_live_freq,
+                    "live_doc_freq term {term:?} field {field}"
+                );
+                assert_eq!(
+                    seg.doc_freq(term, field) as u64,
+                    expected_live_freq,
+                    "doc_freq term {term:?} field {field} (segment has no holes to disagree over)"
+                );
+            }
+        }
+
+        for prefix in ["mo", "b", "z", ""] {
+            let mut mem_terms = Vec::new();
+            mem.collect_terms_with_prefix(prefix, 100, &mut mem_terms);
+            let mut seg_terms = Vec::new();
+            seg.collect_terms_with_prefix(prefix, 100, &mut seg_terms);
+            mem_terms.sort();
+            seg_terms.sort();
+            assert_eq!(mem_terms, seg_terms, "prefix {prefix:?}");
+        }
+
+        for typo in ["mouss", "moose", "mouse"] {
+            let mut mem_fuzzy = Vec::new();
+            mem.collect_fuzzy_terms(&mut FuzzyMatcher::new(typo, 2), &mut mem_fuzzy);
+            let mut seg_fuzzy = Vec::new();
+            seg.collect_fuzzy_terms(&mut FuzzyMatcher::new(typo, 2), &mut seg_fuzzy);
+            mem_fuzzy.sort();
+            seg_fuzzy.sort();
+            assert_eq!(mem_fuzzy, seg_fuzzy, "typo {typo:?}");
+        }
+
+        let brand = seg.keyword_column(2).unwrap();
+        assert_eq!(brand.equals("Logitech").iter().collect::<Vec<_>>(), vec![0]);
+        let price = seg.numeric_column(3).unwrap();
+        assert_eq!(price.range(Some(NumKey::Int(1999)), Some(NumKey::Int(2999))).len(), 2);
+    }
+
+    #[test]
+    fn lookup_and_get_mirror_the_memtable_for_live_docs_only() {
+        let (m, schema) = fixture();
+        let dir = tempfile::tempdir().unwrap();
+        let encoded = super::super::encode(&m, &schema).unwrap();
+        let paths = write_segment(dir.path(), &encoded);
+        let reader = SegmentReader::open(&paths, &schema).unwrap();
+
+        assert_eq!(reader.lookup_id("1"), m.lookup("1"));
+        assert_eq!(reader.lookup_id("2"), m.lookup("2"));
+        assert_eq!(reader.lookup_id("3"), None, "the hole's id must not resolve");
+
+        let doc_id = reader.lookup_id("1").unwrap();
+        assert_eq!(reader.get(doc_id), Some(m.get(doc_id).unwrap().source.clone()));
+    }
+
+    #[test]
+    fn open_rejects_a_schema_with_a_different_field_count() {
+        let (m, schema) = fixture();
+        let dir = tempfile::tempdir().unwrap();
+        let encoded = super::super::encode(&m, &schema).unwrap();
+        let paths = write_segment(dir.path(), &encoded);
+
+        let wrong_schema =
+            CollectionSchema::new("products", vec![FieldSchema::new("title", FieldType::Text)]);
+        assert!(SegmentReader::open(&paths, &wrong_schema).is_err());
+    }
+
+    #[test]
+    fn open_surfaces_a_missing_file_as_an_error_not_a_panic() {
+        let (m, schema) = fixture();
+        let dir = tempfile::tempdir().unwrap();
+        let encoded = super::super::encode(&m, &schema).unwrap();
+        let mut paths = write_segment(dir.path(), &encoded);
+        paths.col = dir.path().join("does-not-exist.col");
+        assert!(SegmentReader::open(&paths, &schema).is_err());
+    }
+
+    #[test]
+    fn a_large_corpus_opens_without_decoding_everything_up_front() {
+        // Not a memory-measurement test (fragile in a unit test), but a
+        // sanity check that `open` really does stay O(terms + fields), not
+        // O(documents): a few thousand documents must open just as fast as a
+        // few, since nothing about `open` scans postings or doc records.
+        let schema = schema();
+        let mut m = MemTable::new(0, &schema);
+        for i in 0..5000 {
+            m.insert(doc(&i.to_string(), &format!("item number {i}"), &["tag"], "Brand", i as i64));
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let encoded = super::super::encode(&m, &schema).unwrap();
+        let paths = write_segment(dir.path(), &encoded);
+
+        let reader = SegmentReader::open(&paths, &schema).unwrap();
+        assert_eq!(reader.min_doc_id(), 0);
+        assert_eq!(reader.end_doc_id(), 5000);
+        assert_eq!(reader.lookup_id("2500"), Some(2500));
+        assert_eq!(reader.get(2500).unwrap()["title"], json!("item number 2500"));
+        assert!(reader.is_live(4999));
+        assert!(!reader.is_live(5000));
+    }
+}

--- a/crates/tachyon-index/src/source.rs
+++ b/crates/tachyon-index/src/source.rs
@@ -3,15 +3,30 @@
 //! A search runs over an ordered list of sources — the memtable plus every
 //! committed segment (PRD §10: "search memtable, search immutable segments,
 //! merge results"). Both sides implement this trait, so the executor never
-//! branches on which one it is holding.
+//! branches on which it is holding.
 //!
 //! Deliberately object-safe: the executor holds `&[&dyn IndexSource]`.
+//!
+//! # Borrowed vs. owned
+//!
+//! Every method that hands back index data returns [`Cow`] rather than a bare
+//! reference. The memtable's data already lives in memory in exactly the
+//! shape callers want, so it returns `Cow::Borrowed` at zero cost — nothing
+//! about the memtable's performance changes. A segment, however, keeps almost
+//! nothing decoded at rest: its postings, columns, and document values are
+//! read from an mmap'd file and decoded into an owned value only when asked
+//! for, which is what keeps a segment's resident memory bounded by corpus
+//! size rather than by how much of it has ever been queried. `Cow` lets one
+//! trait describe both without forcing the memtable to pay a clone it never
+//! needed.
+
+use std::borrow::Cow;
 
 use roaring::RoaringBitmap;
 
 use tachyon_core::{DocId, FieldId, Value};
 
-use crate::columns::Columns;
+use crate::columns::{KeywordColumn, NumericColumn};
 use crate::fuzzy::FuzzyMatcher;
 use crate::inverted::FieldPostings;
 use crate::memtable::MemTable;
@@ -25,18 +40,21 @@ pub trait IndexSource: Send + Sync {
     fn end_doc_id(&self) -> DocId;
 
     /// A document's stored value for a field, used by sorting and the
-    /// popularity signal. O(1): sorting must not scan a column per document.
-    fn value(&self, doc_id: DocId, field: FieldId) -> Option<&Value>;
+    /// popularity signal.
+    fn value(&self, doc_id: DocId, field: FieldId) -> Option<Cow<'_, Value>>;
 
-    /// The filter, sort, and facet columns for this source.
-    fn columns(&self) -> &Columns;
+    /// The numeric filter/sort column for a field, if it has one.
+    fn numeric_column(&self, field: FieldId) -> Option<Cow<'_, NumericColumn>>;
+
+    /// The keyword filter/facet column for a field, if it has one.
+    fn keyword_column(&self, field: FieldId) -> Option<Cow<'_, KeywordColumn>>;
 
     /// Postings for a term in a field, or `None` if absent.
-    fn postings(&self, term: &str, field: FieldId) -> Option<&FieldPostings>;
+    fn postings(&self, term: &str, field: FieldId) -> Option<Cow<'_, FieldPostings>>;
 
     /// Documents in this source containing `term` in `field`.
     fn doc_freq(&self, term: &str, field: FieldId) -> u32 {
-        self.postings(term, field).map_or(0, FieldPostings::doc_freq)
+        self.postings(term, field).map_or(0, |p| p.doc_freq())
     }
 
     /// Documents containing `term` in `field` that are still live.
@@ -98,16 +116,20 @@ impl IndexSource for MemTable {
         self.next_doc_id()
     }
 
-    fn value(&self, doc_id: DocId, field: FieldId) -> Option<&Value> {
-        self.get(doc_id).and_then(|d| d.values.get(field as usize))
+    fn value(&self, doc_id: DocId, field: FieldId) -> Option<Cow<'_, Value>> {
+        self.get(doc_id).and_then(|d| d.values.get(field as usize)).map(Cow::Borrowed)
     }
 
-    fn columns(&self) -> &Columns {
-        MemTable::columns(self)
+    fn numeric_column(&self, field: FieldId) -> Option<Cow<'_, NumericColumn>> {
+        MemTable::columns(self).numeric(field).map(Cow::Borrowed)
     }
 
-    fn postings(&self, term: &str, field: FieldId) -> Option<&FieldPostings> {
-        self.index().postings(term, field)
+    fn keyword_column(&self, field: FieldId) -> Option<Cow<'_, KeywordColumn>> {
+        MemTable::columns(self).keyword(field).map(Cow::Borrowed)
+    }
+
+    fn postings(&self, term: &str, field: FieldId) -> Option<Cow<'_, FieldPostings>> {
+        self.index().postings(term, field).map(Cow::Borrowed)
     }
 
     fn doc_freq(&self, term: &str, field: FieldId) -> u32 {

--- a/crates/tachyon-query/src/executor.rs
+++ b/crates/tachyon-query/src/executor.rs
@@ -28,6 +28,7 @@
 //! `(slot, field, token)`. A newly matched document appends one block; nothing
 //! else allocates.
 
+use std::borrow::Cow;
 use std::cmp::Ordering;
 
 use roaring::RoaringBitmap;
@@ -116,7 +117,7 @@ impl<'a> SearchContext<'a> {
         FieldStats::new(doc_count, total_len)
     }
 
-    fn value(&self, doc_id: DocId, field: FieldId) -> Option<&Value> {
+    fn value(&self, doc_id: DocId, field: FieldId) -> Option<Cow<'a, Value>> {
         self.sources.iter().find_map(|s| {
             (doc_id >= s.min_doc_id() && doc_id < s.end_doc_id()).then(|| s.value(doc_id, field))?
         })
@@ -302,9 +303,13 @@ pub fn execute(ctx: &SearchContext, req: &SearchRequest) -> SearchOutcome {
     let needs_positions = tokens.len() > 1 || !query.phrases.is_empty();
     let mut acc = Accumulator::new(req.query_by.len(), tokens.len(), needs_positions);
 
-    // Reused across candidates so resolving a term against every source does
-    // not allocate per candidate.
-    let mut per_source: Vec<Option<&FieldPostings>> = Vec::with_capacity(ctx.sources.len());
+    // Reused across candidates so the outer `Vec` does not reallocate per
+    // candidate. The `Cow` each slot holds is a zero-cost borrow for a
+    // memtable source but a fresh decode for a segment one — resolving a
+    // term against every source once, rather than once for `doc_freq` and
+    // again for the postings walk, still matters for a segment exactly
+    // because that decode is real work now.
+    let mut per_source: Vec<Option<Cow<'_, FieldPostings>>> = Vec::with_capacity(ctx.sources.len());
 
     for (field_pos, &(field, _boost)) in req.query_by.iter().enumerate() {
         let stats = ctx.field_stats(field);
@@ -321,7 +326,7 @@ pub fn execute(ctx: &SearchContext, req: &SearchRequest) -> SearchOutcome {
                 per_source.extend(ctx.sources.iter().map(|s| s.postings(&candidate.term, field)));
 
                 let doc_freq: u32 =
-                    per_source.iter().map(|p| p.map_or(0, FieldPostings::doc_freq)).sum();
+                    per_source.iter().map(|p| p.as_ref().map_or(0, |p| p.doc_freq())).sum();
                 if doc_freq == 0 {
                     continue;
                 }
@@ -450,7 +455,7 @@ fn finish(
 
         let popularity = popularity_field
             .and_then(|f| ctx.value(doc_id, f))
-            .and_then(Value::as_f64)
+            .and_then(|v| v.as_f64())
             .map(|v| score::normalize_popularity(v as f32))
             .unwrap_or(0.0);
 
@@ -544,7 +549,7 @@ fn sort_values(
         .iter()
         .map(|clause| match clause.key {
             SortKey::TextMatch => SortValue::Score(score),
-            SortKey::Field(field) => sort::sort_value(ctx.value(doc_id, field)),
+            SortKey::Field(field) => sort::sort_value(ctx.value(doc_id, field).as_deref()),
         })
         .collect()
 }

--- a/crates/tachyon-query/src/facets.rs
+++ b/crates/tachyon-query/src/facets.rs
@@ -47,13 +47,11 @@ pub fn compute(
         let mut totals: HashMap<String, u64> = HashMap::new();
 
         for source in &ctx.sources {
-            let columns = source.columns();
-
-            if let Some(keyword) = columns.keyword(field) {
+            if let Some(keyword) = source.keyword_column(field) {
                 for (value, count) in keyword.value_counts_within(matched) {
                     *totals.entry(value.to_string()).or_default() += count;
                 }
-            } else if let Some(numeric) = columns.numeric(field) {
+            } else if let Some(numeric) = source.numeric_column(field) {
                 for (key, count) in numeric.value_counts_within(matched) {
                     *totals.entry(format_key(key)).or_default() += count;
                 }

--- a/crates/tachyon-query/src/filter.rs
+++ b/crates/tachyon-query/src/filter.rs
@@ -397,11 +397,10 @@ pub fn evaluate(expr: &FilterExpr, sources: &[&dyn IndexSource]) -> RoaringBitma
 }
 
 fn eval_predicate(predicate: &Predicate, source: &dyn IndexSource) -> RoaringBitmap {
-    let columns = source.columns();
     let field = predicate.field;
 
     // A field can have a numeric column or a keyword one, never both.
-    if let Some(numeric) = columns.numeric(field) {
+    if let Some(numeric) = source.numeric_column(field) {
         return match &predicate.op {
             PredOp::Eq(FilterValue::Num(k)) => numeric.range(Some(*k), Some(*k)),
             PredOp::Ne(FilterValue::Num(k)) => numeric.not_equal(*k),
@@ -433,7 +432,7 @@ fn eval_predicate(predicate: &Predicate, source: &dyn IndexSource) -> RoaringBit
         };
     }
 
-    if let Some(keyword) = columns.keyword(field) {
+    if let Some(keyword) = source.keyword_column(field) {
         return match &predicate.op {
             PredOp::Eq(FilterValue::Text(v)) => keyword.equals(v),
             PredOp::Ne(FilterValue::Text(v)) => keyword.not_equal(v),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,6 +105,78 @@ surfaces years later in someone's id column.
 answers an equality filter (return the bitmap) and a facet count (its
 cardinality).
 
+## Segments
+
+A flush turns a memtable into five immutable files — `<id>.terms`, `<id>.ids`,
+`<id>.post`, `<id>.col`, `<id>.doc` — under `segments/`, one file per
+structure rather than one shared blob, so postings, columns, and the document
+store can each use whatever layout suits them without agreeing on a common
+framing. `.terms` and `.ids` are `fst::Map`s (term → dense id, and user id →
+doc id); `.post`, `.col`, and `.doc` each carry a small eager header — an
+offset table, essentially — followed by the data it points into.
+
+Every file is mmap'd, and every read decodes only what it was asked for:
+
+- **`.post`**: the header holds per-field corpus stats and a byte offset per
+  term. A query resolves a term through `.terms`' FST to a dense id, then
+  decodes just that one term's block — nothing else in the file is touched.
+  `doc_freq`/`live_doc_freq` go further still: they only ever need a document
+  count or a liveness check, never positions, so they walk the block skipping
+  position arrays instead of decoding and allocating them — the difference
+  matters because autocomplete calls both across every candidate term and
+  every source.
+- **`.col`**: the header is a small per-field directory (tag, offset,
+  length). A query decodes one field's column — reusing
+  `NumericColumn`/`KeywordColumn` verbatim via `from_sorted`/`from_parts` —
+  never the whole file.
+- **`.doc`**: field lengths and per-field values sit in dense, fixed-width
+  arrays indexed directly by `doc_id`, so BM25's `|d|` and a numeric/bool
+  field's value cost a bounds-checked read at a computed offset — no decode
+  step, no allocation. Text and array values, and the document's source JSON,
+  are variable-length and read on demand through a small offset directory;
+  the source in particular is parsed only when a matched document actually
+  becomes a returned hit, not for every document a query scores.
+
+`IndexSource`'s methods reflect this: `postings`, `numeric_column`,
+`keyword_column`, and `value` all return `Cow<'_, T>` rather than `&T`. The
+memtable returns `Cow::Borrowed` — its data already lives in memory in the
+shape callers want, so nothing about its cost changes. A segment returns
+`Cow::Owned`, built fresh from the mapped bytes on every call. That's the
+whole trade: a segment pays a small decode per query instead of holding
+everything decoded at rest, which is what keeps a segment's resident memory
+bounded by how much of it is queried rather than by its size on disk.
+
+Segments still win on two fronts a memtable can't, independent of laziness:
+the files survive a restart, so replay is bounded to the WAL generation
+opened after the last flush rather than the whole log, and a flush holds
+nothing for a document deleted before it — the memtable's own postings and
+columns are never pruned until then.
+
+A flush also has to tell apart two reasons a doc id can be missing from a
+segment, and conflating them would either resurrect a deleted document or
+silently drop a live one:
+
+- **Never written.** A document deleted from the memtable before ever being
+  flushed leaves nothing behind — no postings, no column entries, no doc
+  record. A segment-local presence bitmap records exactly which ids in its
+  `[min_doc_id, max_doc_id]` range were live at flush time, and
+  `IndexSource::is_live` answers from that alone.
+- **Deleted after commit.** A document deleted, or superseded by an upsert,
+  once it already lives in a segment is tombstoned in the collection-wide
+  `deleted` bitmap — the same one `state.json` persists — which the executor
+  checks separately from `is_live` (see "Reading" below). A segment reader
+  never sees these; it only ever answers "was this id written here."
+
+Flushing runs under the same write-lock acquisition as the mutation that
+triggered it, start to finish. Splitting it into separate acquisitions would
+let a concurrent write's WAL record land at or below the `applied_seq` this
+flush is about to commit — silently excluded from every future replay despite
+never having reached a segment. Segment files are written before `state.json`
+is replaced, so a crash between the two leaves orphaned files at an id nothing
+references; `Collection::open` never scans the `segments/` directory, only the
+ids `state.json` names, so a later flush reusing that id simply overwrites
+them.
+
 ## Reading
 
 A search runs over an ordered list of sources — the memtable, then every
@@ -167,21 +239,28 @@ minimum over budget (abandon mid-matrix). Most terms die on the length check.
 ## Concurrency
 
 Each collection is an `RwLock` over its mutable state. Searches take the read
-lock and run concurrently with each other; a write holds the write lock only
-for the WAL append and the memtable update. This is deliberately simple, and it
-is the obvious place to look when write throughput under concurrent search
-becomes the bottleneck — the next step would be an atomically-swapped read
-snapshot so searches never block at all.
+lock and run concurrently with each other; a write normally holds the write
+lock only for the WAL append and the memtable update, except when it also
+triggers a flush — that runs to completion under the same acquisition (see
+"Segments"), so the occasional write that crosses the memtable threshold
+blocks readers for the length of a segment encode and write rather than a WAL
+append. This is deliberately simple, and it is the obvious place to look when
+write throughput under concurrent search becomes the bottleneck — the next
+step would be an atomically-swapped read snapshot so searches never block at
+all.
 
 ## What is not built yet
 
-**Segment flush.** The memtable is never written to disk, so memory grows with
-the corpus and startup replays the whole log. Everything around it exists: the
-commit protocol, WAL generations, tombstone bitmaps, and the `IndexSource`
-abstraction segments plug into. This is the most important next piece of work.
+**Tiered merges.** Nothing yet bounds how many segments a long-lived
+collection accumulates, or reclaims the space a document occupies across a
+delete-then-merge. This is the more pressing of the two remaining gaps:
+`SearchContext.sources` is a flat `Vec`, so a query fans out across the
+memtable plus every committed segment with nothing merging them back down,
+and each segment pays its own decode independently. Measured search p95 over
+HTTP, default 100k-document flush threshold: ~9ms at 100k docs (1 segment),
+~88ms at 1M (10 segments), ~524ms at 5M (50 segments) — segment count, not
+corpus size alone, is doing most of that. Bounding it is what fixes that.
 
 **Block-max WAND.** The executor scores every match. Early termination would
 let it skip documents that cannot reach the top-K, which is what broad queries
-on large corpora need.
-
-**Tiered merges.** Follows segments.
+on large corpora need — independent of, and complementary to, tiered merges.


### PR DESCRIPTION
Flushes the memtable into immutable on-disk segments once max-memtable-docs/max-memtable-bytes is crossed, closing the two gaps called out in the architecture doc: unbounded WAL replay on restart and postings/columns that were never reclaimed for documents deleted before a flush.

Segments are read lazily rather than decoded wholesale at open time: every file (.terms, .ids, .post, .col, .doc) is mmap'd, postings and columns are decoded per-term/per-field through offset tables, and document field lengths and scalar values are addressed directly at a computed byte offset with no decode step at all. IndexSource now returns Cow<'_, T> instead of &T so segments can hand back freshly decoded data while the memtable keeps returning free borrows.

Verified against Typesense 27.1 in matched Docker containers: 5M documents that previously OOM-killed the container (eager decode held everything from every segment resident) now index in ~98s at 539 MiB peak, versus Typesense's ~250s at 1.9 GiB.