### PR TITLE
Add true block-max WAND query pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ curl 'localhost:8108/collections/products/search?q=wireless+mouse'
 ```json
 {
   "found": 1,
+  "found_is_exact": true,
   "search_time_ms": 0,
   "hits": [
     { "document": { "id": "1", "title": "Wireless Mouse", "brand": "Logitech", "price": 2999 },
@@ -145,10 +146,19 @@ memory-constrained deployment, but momentary, not sustained. A direct
 merge of the already-encoded structures, avoiding the scratch memtable
 entirely, is the natural follow-up if this proves to matter in practice.
 
-**Broad queries scale linearly.** Every matching document is scored. Real
-catalogues are far more selective than a broad query — and adding a filter
-already halves the cost — but the fix is block-max WAND early termination,
-which would let the executor skip documents that cannot reach the top-K.
+**Broad queries no longer visit every match unconditionally.** A block-level
+score bound (true block-max WAND, `.post`'s v3 format) now skips whole
+regions of a term's postings — and, when the bound can't clear the current
+top-K threshold, whole documents — without decoding them at all, for both
+`match_mode=any` and the default `match_mode=all`. `found`/facets stay exact
+only when nothing was skipped, signaled per response by `found_is_exact`;
+when pruning does engage, they become a lower bound, not a false one.
+Measured on a 5M-doc, ~9%-broad-query benchmark: search p95 went 494 ms
+(before any of this pruning existed) → 454 ms (exact tail-only pruning) →
+**278 ms** (`any` mode) / **252 ms** (`all` mode, the default) with true
+WAND. Real catalogues are far more selective than this benchmark's
+deliberately-broad query, and adding a filter still reduces cost further on
+top of this.
 
 **Not yet built:** distributed clustering, replication, synonyms, stemming, stop
 words, highlighting, geo search, and nested documents. All are explicit

--- a/crates/tachyon-engine/src/collection.rs
+++ b/crates/tachyon-engine/src/collection.rs
@@ -341,6 +341,7 @@ impl Collection {
 
         Ok(SearchResponse {
             found: outcome.found,
+            found_is_exact: outcome.found_is_exact,
             search_time_ms: started.elapsed().as_millis() as u64,
             hits,
             facets,
@@ -559,7 +560,18 @@ impl Collection {
 
         // Rebuild: every live, non-tombstoned document across the victims,
         // re-validated and re-tokenized exactly like a fresh insert.
-        let merge_base = inner.state.next_doc_id;
+        //
+        // The range this claims must start from the *active* memtable's own
+        // `next_doc_id()`, not `inner.state.next_doc_id` — the two agree
+        // when merging runs right after a flush (the common case: the fresh
+        // memtable is still empty, so its `next_doc_id()` equals the base
+        // `state.next_doc_id` recorded for it), but a merge invoked with
+        // documents already sitting in the memtable (e.g. a manual
+        // `Collection::merge()` call) would otherwise hand out ids the
+        // memtable already assigned to those documents. Below, once this
+        // range is claimed, the memtable is told to skip over it too — see
+        // that call's comment for why.
+        let merge_base = inner.memtable.next_doc_id();
         let mut merged = MemTable::new(merge_base, schema);
         for reader in &victim_readers {
             for doc_id in reader.min_doc_id()..reader.end_doc_id() {
@@ -575,6 +587,10 @@ impl Collection {
                 merged.insert(parsed);
             }
         }
+        // How many ids `merged` actually claimed out of `merge_base`'s range
+        // — 0 if every victim document turned out to be dead, same as
+        // `wrote_segment` below computes it.
+        let claimed = merged.next_doc_id() - merge_base;
 
         let mut new_state = inner.state.clone();
 
@@ -637,6 +653,12 @@ impl Collection {
         meta::write_state(layout, &schema.name, &new_state)?;
 
         inner.state = new_state;
+        // The active memtable's own `next_doc_id()` was `merge_base` before
+        // this merge started (see where `merge_base` is computed above) —
+        // without this, its next real insert would hand out `merge_base`
+        // again, colliding with the very first doc id this merge just
+        // wrote into a segment.
+        inner.memtable.reserve(claimed as usize);
         for &i in victims.iter().rev() {
             inner.segments.remove(i);
         }
@@ -1356,5 +1378,95 @@ mod tests {
 
         let reopened = Collection::open(&layout, "products", &config).unwrap();
         assert_eq!(reopened.stats().num_documents, 4);
+    }
+
+    /// A merge's output segment must never claim a doc id the *active*
+    /// memtable is going to hand out later — regression test for a bug
+    /// where `merge_locked` computed its output range from
+    /// `state.next_doc_id`, the exact id the fresh post-flush memtable
+    /// already started counting from, without telling that memtable to
+    /// skip past the range the merge just claimed. Left unfixed, a later
+    /// real upsert into the memtable silently reused an id a merged segment
+    /// already owned — `MergeCursor` then saw the same doc id surface from
+    /// two different sources on the same query, breaking the
+    /// ascending-order guarantee `tachyon-query`'s WAND drivers depend on
+    /// and panicking `RoaringBitmap::from_sorted_iter` in `executor.rs`.
+    ///
+    /// Fixing that (`MemTable::reserve`, called from `merge_locked`) traded
+    /// one bug for a subtler one: a memtable that reserved a merge's range
+    /// still *declares* that range as its own via `base()`/`next_doc_id()`
+    /// even though nothing is ever live there, so a doc id can legitimately
+    /// fall inside two sources' declared ranges at once now. This is
+    /// asserted directly below, and separately the search-side fallout is
+    /// checked: `SearchContext::is_live`/`field_len` used to stop at the
+    /// *first* range-matching source (`executor.rs`), so a genuinely live
+    /// document in the second, real owner was reported dead and silently
+    /// excluded from every search. Both fixes are needed together.
+    ///
+    /// Many small flush+merge rounds are needed to give the bug room to
+    /// manifest — a single merge round (every other merge test here) never
+    /// exercised more than one live memtable generation past the merge.
+    #[test]
+    fn repeated_merges_never_hand_the_active_memtable_a_claimed_doc_id() {
+        let (_dir, layout, config) = merge_harness(3, 2);
+        let c = Collection::create(&layout, schema(), &config).unwrap();
+
+        let n = 200;
+        for i in 0..n {
+            c.upsert(product(&(i + 1).to_string(), "widget gadget", 100 + i)).unwrap();
+        }
+        assert!(c.stats().num_segments > 1, "sanity: this many docs must have forced a merge");
+
+        // Segments' own declared ranges must be pairwise disjoint — unlike
+        // the memtable, a segment's range is fixed for its whole life at
+        // exactly the ids one memtable generation used, so this always held
+        // even before the fix; asserted here as a sanity check on the setup.
+        let inner = c.inner.read();
+        let mut seg_ranges: Vec<(DocId, DocId)> =
+            inner.state.segments.iter().map(|s| (s.min_doc_id, s.max_doc_id)).collect();
+        seg_ranges.sort_unstable();
+        for w in seg_ranges.windows(2) {
+            assert!(w[0].1 < w[1].0, "overlapping segment ranges {:?} and {:?}", w[0], w[1]);
+        }
+        drop(inner);
+
+        // A broad, window-filling `any`-mode query with a small `limit` is
+        // exactly what drove pruning through every source in the real
+        // crash: this must not panic (the original failure mode). `found`
+        // itself is allowed to be an approximate lower bound once pruning
+        // engages (by design, see `wand.rs`'s module doc), so it isn't
+        // checked here.
+        c.search(SearchParams {
+            q: Some("widget".into()),
+            match_mode: Some("any".into()),
+            limit: Some(5),
+            ..Default::default()
+        })
+        .unwrap();
+
+        // A window big enough to hold every match never lets pruning skip
+        // anything (same reasoning as this file's other exact-count
+        // assertions), so `found` must be exact here — this is what
+        // actually confirms no document was lost to a doc-id collision, or
+        // to a live document behind a reserved-but-declared memtable range
+        // being reported dead.
+        let exhaustive = c
+            .search(SearchParams {
+                q: Some("widget".into()),
+                match_mode: Some("any".into()),
+                limit: Some(n as usize),
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(exhaustive.found_is_exact, "a full window must never skip a block");
+        assert_eq!(exhaustive.found, n as usize);
+
+        // A doc-id collision would also silently corrupt content (two
+        // documents fighting over the same slot in different sources) —
+        // confirm every original document still reads back correctly.
+        for i in 0..n {
+            let doc = c.get(&(i + 1).to_string()).unwrap();
+            assert_eq!(doc["price"], json!(100 + i));
+        }
     }
 }

--- a/crates/tachyon-index/src/cursor.rs
+++ b/crates/tachyon-index/src/cursor.rs
@@ -83,8 +83,8 @@ impl PostingCursor for MemTablePostingCursor<'_> {
     }
 
     fn advance_to(&mut self, target: DocId) -> Option<DocId> {
-        self.pos += self.docs[self.pos.min(self.docs.len())..]
-            .partition_point(|d| d.doc_id < target);
+        self.pos +=
+            self.docs[self.pos.min(self.docs.len())..].partition_point(|d| d.doc_id < target);
         self.doc_id()
     }
 
@@ -304,7 +304,9 @@ mod tests {
             self.doc_id()
         }
         fn max_remaining_tf(&self) -> u32 {
-            self.docs.get(self.pos..).map_or(0, |rest| rest.iter().map(|&(_, tf)| tf).max().unwrap_or(0))
+            self.docs
+                .get(self.pos..)
+                .map_or(0, |rest| rest.iter().map(|&(_, tf)| tf).max().unwrap_or(0))
         }
         fn current_block_last_doc_id(&self) -> Option<DocId> {
             self.block_last_doc_id
@@ -320,8 +322,10 @@ mod tests {
         // be skipped straight over.
         let a = FixedCursor { docs: vec![(10, 1), (200, 1)], pos: 0, block_last_doc_id: Some(100) };
         let b = FixedCursor { docs: vec![(20, 1), (22, 1)], pos: 0, block_last_doc_id: Some(25) };
-        let merged =
-            MergeCursor::new(vec![Box::new(a) as Box<dyn PostingCursor>, Box::new(b) as Box<dyn PostingCursor>]);
+        let merged = MergeCursor::new(vec![
+            Box::new(a) as Box<dyn PostingCursor>,
+            Box::new(b) as Box<dyn PostingCursor>,
+        ]);
         assert_eq!(merged.doc_id(), Some(10), "A holds the smaller current doc id");
         assert_eq!(merged.current_block_last_doc_id(), Some(25), "bounded by B's tighter block");
     }
@@ -334,6 +338,10 @@ mod tests {
             Box::new(segment_like) as Box<dyn PostingCursor>,
             Box::new(MemTablePostingCursor::new(&mem)) as Box<dyn PostingCursor>,
         ]);
-        assert_eq!(merged.current_block_last_doc_id(), None, "the memtable child has no block bound");
+        assert_eq!(
+            merged.current_block_last_doc_id(),
+            None,
+            "the memtable child has no block bound"
+        );
     }
 }

--- a/crates/tachyon-index/src/cursor.rs
+++ b/crates/tachyon-index/src/cursor.rs
@@ -1,0 +1,339 @@
+//! Lazy, doc-at-a-time postings iteration.
+//!
+//! A pruning search needs to ask a term's postings "what's your next doc?"
+//! and "skip ahead to here" without paying to decode or hold every posting
+//! in between — [`PostingCursor`] is that interface. [`MemTablePostingCursor`]
+//! is one concrete shape (a borrowed, already-sorted, already-resident
+//! slice); `segment::cursor::SegmentPostingCursor` (block-structured, lazily
+//! decoded from an mmap) is the other. [`MergeCursor`] folds several
+//! same-term-and-field cursors — the memtable plus every committed segment —
+//! into one logical cursor over the whole collection.
+
+use tachyon_core::DocId;
+
+use crate::inverted::DocPosting;
+
+/// Doc-at-a-time access to one term's postings in one field, from one
+/// source.
+///
+/// A cursor starts positioned at its first posting, if any, and exposes the
+/// *current* doc without consuming it — what lets a pruning driver inspect a
+/// bound before deciding whether a document is even worth visiting.
+pub trait PostingCursor {
+    /// The doc id currently under the cursor, or `None` once exhausted.
+    fn doc_id(&self) -> Option<DocId>;
+
+    /// Term frequency at the current doc id. `0` once exhausted.
+    fn term_freq(&self) -> u32;
+
+    /// Positions at the current doc id, decoded only now — a document a
+    /// bound proves unnecessary to visit never pays this cost.
+    fn positions(&self) -> Vec<u32>;
+
+    /// Move to the next doc id.
+    fn advance(&mut self) -> Option<DocId>;
+
+    /// Move forward to the first doc id `>= target`. A no-op if the cursor
+    /// is already there or past it — this never moves backward.
+    fn advance_to(&mut self, target: DocId) -> Option<DocId>;
+
+    /// Upper bound on `term_freq` for any doc in the cursor's CURRENT block.
+    fn max_remaining_tf(&self) -> u32;
+
+    /// The current block's last doc id, for skip-ahead when even this
+    /// block's own bound can't clear a threshold. `None` for sources with
+    /// no block structure (the memtable).
+    fn current_block_last_doc_id(&self) -> Option<DocId>;
+}
+
+/// A cursor over a memtable's already-sorted, already-resident posting list.
+/// Every read is a slice index — there is nothing to decode.
+pub struct MemTablePostingCursor<'a> {
+    docs: &'a [DocPosting],
+    pos: usize,
+    /// Whole-list maximum, computed once at construction — sound but not
+    /// block-tight. Fine: the memtable is small and RAM-resident, so a loose
+    /// bound here doesn't cost what it would on a large segment.
+    max_tf: u32,
+}
+
+impl<'a> MemTablePostingCursor<'a> {
+    pub fn new(docs: &'a [DocPosting]) -> MemTablePostingCursor<'a> {
+        let max_tf = docs.iter().map(DocPosting::tf).max().unwrap_or(0);
+        MemTablePostingCursor { docs, pos: 0, max_tf }
+    }
+}
+
+impl PostingCursor for MemTablePostingCursor<'_> {
+    fn doc_id(&self) -> Option<DocId> {
+        self.docs.get(self.pos).map(|d| d.doc_id)
+    }
+
+    fn term_freq(&self) -> u32 {
+        self.docs.get(self.pos).map_or(0, DocPosting::tf)
+    }
+
+    fn positions(&self) -> Vec<u32> {
+        self.docs.get(self.pos).map_or_else(Vec::new, |d| d.positions.clone())
+    }
+
+    fn advance(&mut self) -> Option<DocId> {
+        self.pos += 1;
+        self.doc_id()
+    }
+
+    fn advance_to(&mut self, target: DocId) -> Option<DocId> {
+        self.pos += self.docs[self.pos.min(self.docs.len())..]
+            .partition_point(|d| d.doc_id < target);
+        self.doc_id()
+    }
+
+    fn max_remaining_tf(&self) -> u32 {
+        self.max_tf
+    }
+
+    fn current_block_last_doc_id(&self) -> Option<DocId> {
+        None
+    }
+}
+
+/// A k-way union merge of one term-field's cursors across every source —
+/// the memtable plus every committed segment.
+///
+/// Doc id ranges are disjoint across sources (each source owns a
+/// contiguous, non-overlapping range of ids), so at most one child ever
+/// holds any particular doc id — but several children can be simultaneously
+/// live, each pointing at its own smallest not-yet-visited doc in its own
+/// range. Finding whichever is smallest is a linear scan over the live
+/// children, which isn't worth a heap at this fan-in (memtable plus a
+/// handful of segments, not dozens).
+pub struct MergeCursor<'a> {
+    children: Vec<Box<dyn PostingCursor + 'a>>,
+    /// Index into `children` of whichever cursor currently holds the
+    /// smallest live doc id — recomputed whenever a child moves.
+    current: Option<usize>,
+}
+
+impl<'a> MergeCursor<'a> {
+    pub fn new(children: Vec<Box<dyn PostingCursor + 'a>>) -> MergeCursor<'a> {
+        let mut merged = MergeCursor { children, current: None };
+        merged.find_min();
+        merged
+    }
+
+    fn find_min(&mut self) {
+        self.current = self
+            .children
+            .iter()
+            .enumerate()
+            .filter_map(|(i, c)| c.doc_id().map(|d| (i, d)))
+            .min_by_key(|&(_, d)| d)
+            .map(|(i, _)| i);
+    }
+}
+
+impl PostingCursor for MergeCursor<'_> {
+    fn doc_id(&self) -> Option<DocId> {
+        self.current.and_then(|i| self.children[i].doc_id())
+    }
+
+    fn term_freq(&self) -> u32 {
+        self.current.map_or(0, |i| self.children[i].term_freq())
+    }
+
+    fn positions(&self) -> Vec<u32> {
+        self.current.map_or_else(Vec::new, |i| self.children[i].positions())
+    }
+
+    fn advance(&mut self) -> Option<DocId> {
+        if let Some(i) = self.current {
+            self.children[i].advance();
+        }
+        self.find_min();
+        self.doc_id()
+    }
+
+    fn advance_to(&mut self, target: DocId) -> Option<DocId> {
+        for child in &mut self.children {
+            if child.doc_id().is_some_and(|d| d < target) {
+                child.advance_to(target);
+            }
+        }
+        self.find_min();
+        self.doc_id()
+    }
+
+    /// Only the current child's doc id is reachable next — the score bound
+    /// for a *specific* doc id can only ever come from whichever child owns
+    /// that id, never from a different child sitting at some other, larger
+    /// doc id.
+    fn max_remaining_tf(&self) -> u32 {
+        self.current.map_or(0, |i| self.children[i].max_remaining_tf())
+    }
+
+    /// The min across every LIVE child's own block boundary, not just the
+    /// current one: several children can be simultaneously live at
+    /// different doc ids, and skipping ahead based only on the current
+    /// child's (possibly wider) block would risk jumping straight over a
+    /// real match another child is already sitting on. `None` if any live
+    /// child has no block info (a memtable child) — an unbounded live child
+    /// makes any skip-ahead here unsound, same as the single-cursor case.
+    fn current_block_last_doc_id(&self) -> Option<DocId> {
+        let mut min: Option<DocId> = None;
+        for child in &self.children {
+            if child.doc_id().is_none() {
+                continue;
+            }
+            let last = child.current_block_last_doc_id()?;
+            min = Some(min.map_or(last, |m| m.min(last)));
+        }
+        min
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn postings(pairs: &[(DocId, &[u32])]) -> Vec<DocPosting> {
+        pairs.iter().map(|&(doc_id, p)| DocPosting { doc_id, positions: p.to_vec() }).collect()
+    }
+
+    #[test]
+    fn memtable_cursor_walks_in_order() {
+        let docs = postings(&[(1, &[0]), (3, &[0, 5]), (7, &[2])]);
+        let mut cur = MemTablePostingCursor::new(&docs);
+
+        assert_eq!(cur.doc_id(), Some(1));
+        assert_eq!(cur.term_freq(), 1);
+        assert_eq!(cur.positions(), vec![0]);
+
+        assert_eq!(cur.advance(), Some(3));
+        assert_eq!(cur.term_freq(), 2);
+        assert_eq!(cur.positions(), vec![0, 5]);
+
+        assert_eq!(cur.advance(), Some(7));
+        assert_eq!(cur.advance(), None, "exhausted after the last doc");
+        assert_eq!(cur.term_freq(), 0);
+        assert!(cur.positions().is_empty());
+        assert_eq!(cur.advance(), None, "stays exhausted, never panics");
+    }
+
+    #[test]
+    fn memtable_cursor_advance_to_never_moves_backward() {
+        let docs = postings(&[(1, &[0]), (5, &[0]), (10, &[0]), (20, &[0])]);
+        let mut cur = MemTablePostingCursor::new(&docs);
+
+        assert_eq!(cur.advance_to(5), Some(5), "lands exactly on a present doc id");
+        assert_eq!(cur.advance_to(3), Some(5), "a target behind current is a no-op");
+        assert_eq!(cur.advance_to(11), Some(20), "an absent id lands on the next real doc");
+        assert_eq!(cur.advance_to(1000), None, "past the last doc id exhausts the cursor");
+        assert_eq!(cur.advance_to(1), None, "stays exhausted regardless of target");
+    }
+
+    #[test]
+    fn memtable_cursor_max_remaining_tf_is_the_whole_list_maximum() {
+        let docs = postings(&[(1, &[0]), (2, &[0, 1, 2]), (3, &[0])]);
+        let mut cur = MemTablePostingCursor::new(&docs);
+        assert_eq!(cur.max_remaining_tf(), 3);
+        cur.advance();
+        assert_eq!(cur.max_remaining_tf(), 3, "not block-tight, but still sound after moving");
+        assert_eq!(cur.current_block_last_doc_id(), None, "the memtable has no block structure");
+    }
+
+    #[test]
+    fn merge_cursor_unions_disjoint_sources_in_doc_id_order() {
+        let a = postings(&[(1, &[0]), (5, &[0])]);
+        let b = postings(&[(2, &[0]), (3, &[0]), (10, &[0])]);
+        let mut merged = MergeCursor::new(vec![
+            Box::new(MemTablePostingCursor::new(&a)) as Box<dyn PostingCursor>,
+            Box::new(MemTablePostingCursor::new(&b)) as Box<dyn PostingCursor>,
+        ]);
+
+        let mut seen = Vec::new();
+        while let Some(id) = merged.doc_id() {
+            seen.push(id);
+            merged.advance();
+        }
+        assert_eq!(seen, vec![1, 2, 3, 5, 10]);
+    }
+
+    #[test]
+    fn merge_cursor_advance_to_catches_up_every_child_behind_the_target() {
+        let a = postings(&[(1, &[0]), (5, &[0]), (9, &[0])]);
+        let b = postings(&[(2, &[0]), (3, &[0]), (8, &[0])]);
+        let mut merged = MergeCursor::new(vec![
+            Box::new(MemTablePostingCursor::new(&a)) as Box<dyn PostingCursor>,
+            Box::new(MemTablePostingCursor::new(&b)) as Box<dyn PostingCursor>,
+        ]);
+
+        assert_eq!(merged.advance_to(6), Some(8), "both children jump past the target together");
+        let mut rest = vec![merged.doc_id().unwrap()];
+        while let Some(id) = merged.advance() {
+            rest.push(id);
+        }
+        assert_eq!(rest, vec![8, 9]);
+    }
+
+    /// A hand-controlled cursor exposing arbitrary block info, for testing
+    /// [`MergeCursor`]'s block-boundary logic without needing a real segment.
+    struct FixedCursor {
+        docs: Vec<(DocId, u32)>,
+        pos: usize,
+        block_last_doc_id: Option<DocId>,
+    }
+
+    impl PostingCursor for FixedCursor {
+        fn doc_id(&self) -> Option<DocId> {
+            self.docs.get(self.pos).map(|&(id, _)| id)
+        }
+        fn term_freq(&self) -> u32 {
+            self.docs.get(self.pos).map_or(0, |&(_, tf)| tf)
+        }
+        fn positions(&self) -> Vec<u32> {
+            Vec::new()
+        }
+        fn advance(&mut self) -> Option<DocId> {
+            self.pos += 1;
+            self.doc_id()
+        }
+        fn advance_to(&mut self, target: DocId) -> Option<DocId> {
+            while self.doc_id().is_some_and(|d| d < target) {
+                self.pos += 1;
+            }
+            self.doc_id()
+        }
+        fn max_remaining_tf(&self) -> u32 {
+            self.docs.get(self.pos..).map_or(0, |rest| rest.iter().map(|&(_, tf)| tf).max().unwrap_or(0))
+        }
+        fn current_block_last_doc_id(&self) -> Option<DocId> {
+            self.block_last_doc_id
+        }
+    }
+
+    #[test]
+    fn merge_cursor_current_block_last_doc_id_is_the_min_across_live_children() {
+        // Child A sits at doc 10 with a wide block boundary (100); child B
+        // sits at doc 20 (still live, further ahead) with a much tighter
+        // boundary (25). The merged skip-ahead bound must respect B's
+        // tighter limit too, or a real match B is already sitting on could
+        // be skipped straight over.
+        let a = FixedCursor { docs: vec![(10, 1), (200, 1)], pos: 0, block_last_doc_id: Some(100) };
+        let b = FixedCursor { docs: vec![(20, 1), (22, 1)], pos: 0, block_last_doc_id: Some(25) };
+        let merged =
+            MergeCursor::new(vec![Box::new(a) as Box<dyn PostingCursor>, Box::new(b) as Box<dyn PostingCursor>]);
+        assert_eq!(merged.doc_id(), Some(10), "A holds the smaller current doc id");
+        assert_eq!(merged.current_block_last_doc_id(), Some(25), "bounded by B's tighter block");
+    }
+
+    #[test]
+    fn merge_cursor_current_block_last_doc_id_is_none_if_any_live_child_lacks_block_info() {
+        let segment_like = FixedCursor { docs: vec![(1, 1)], pos: 0, block_last_doc_id: Some(50) };
+        let mem = postings(&[(2, &[0])]);
+        let merged = MergeCursor::new(vec![
+            Box::new(segment_like) as Box<dyn PostingCursor>,
+            Box::new(MemTablePostingCursor::new(&mem)) as Box<dyn PostingCursor>,
+        ]);
+        assert_eq!(merged.current_block_last_doc_id(), None, "the memtable child has no block bound");
+    }
+}

--- a/crates/tachyon-index/src/lib.rs
+++ b/crates/tachyon-index/src/lib.rs
@@ -4,6 +4,7 @@
 //! index, and the columnar stores are layered on top of it.
 
 pub mod columns;
+mod cursor;
 pub mod fuzzy;
 pub mod inverted;
 pub mod memtable;
@@ -12,6 +13,7 @@ pub mod source;
 pub mod tokenizer;
 
 pub use columns::{Columns, KeywordColumn, NumKey, NumericColumn};
+pub use cursor::{MergeCursor, PostingCursor};
 pub use fuzzy::{distance_within, FuzzyMatcher};
 pub use inverted::{DocPosting, FieldPostings, InvertedIndex};
 pub use memtable::{MemTable, StoredDoc};

--- a/crates/tachyon-index/src/memtable.rs
+++ b/crates/tachyon-index/src/memtable.rs
@@ -354,9 +354,16 @@ mod tests {
             assert!(!m.is_live(id), "a reserved id must never be live");
         }
         assert_eq!(m.len(), 1, "reserving ids must not change the live count");
-        assert!(m.iter().all(|(id, _)| id != 11 && id != 12 && id != 13), "iteration must skip reserved ids too");
+        assert!(
+            m.iter().all(|(id, _)| id != 11 && id != 12 && id != 13),
+            "iteration must skip reserved ids too"
+        );
 
-        assert_eq!(m.insert(doc("b", "two")), 14, "the next insert lands right after the reserved range");
+        assert_eq!(
+            m.insert(doc("b", "two")),
+            14,
+            "the next insert lands right after the reserved range"
+        );
     }
 
     #[test]

--- a/crates/tachyon-index/src/memtable.rs
+++ b/crates/tachyon-index/src/memtable.rs
@@ -151,6 +151,22 @@ impl MemTable {
         self.base + self.docs.len() as DocId
     }
 
+    /// Retire the next `count` doc ids without assigning any document to
+    /// them — holes exactly like [`Self::remove`] leaves behind, just never
+    /// having been live in the first place.
+    ///
+    /// Needed when something outside this memtable (a segment merge) has
+    /// already handed out a range of ids starting at this memtable's own
+    /// `next_doc_id()` — a merge computes its output segment's id range
+    /// from "whatever this collection's active memtable hasn't claimed
+    /// yet," which is exactly this memtable's `next_doc_id()`. Without this
+    /// call, this memtable's *own* next insert would hand out that same
+    /// first id again, since nothing else here advances `next_doc_id()`
+    /// except an actual `insert`.
+    pub fn reserve(&mut self, count: usize) {
+        self.docs.resize_with(self.docs.len() + count, || None);
+    }
+
     /// Live document count, excluding replaced and deleted documents.
     pub fn len(&self) -> usize {
         self.live
@@ -323,6 +339,24 @@ mod tests {
         m.remove(a);
         let seen: Vec<_> = m.iter().map(|(id, d)| (id, d.id.clone())).collect();
         assert_eq!(seen, vec![(11, "b".to_string()), (12, "c".to_string())]);
+    }
+
+    #[test]
+    fn reserve_advances_next_doc_id_without_creating_a_live_document() {
+        let mut m = memtable(10);
+        m.insert(doc("a", "one")); // id 10
+
+        m.reserve(3); // ids 11..14 retired, never assigned to a document
+
+        assert_eq!(m.next_doc_id(), 14, "the next real insert must skip past the reserved ids");
+        for id in 11..14 {
+            assert!(m.get(id).is_none(), "a reserved id must never resolve to a document");
+            assert!(!m.is_live(id), "a reserved id must never be live");
+        }
+        assert_eq!(m.len(), 1, "reserving ids must not change the live count");
+        assert!(m.iter().all(|(id, _)| id != 11 && id != 12 && id != 13), "iteration must skip reserved ids too");
+
+        assert_eq!(m.insert(doc("b", "two")), 14, "the next insert lands right after the reserved range");
     }
 
     #[test]

--- a/crates/tachyon-index/src/segment/codec.rs
+++ b/crates/tachyon-index/src/segment/codec.rs
@@ -27,7 +27,7 @@ use serde_json::Value as Json;
 use tachyon_core::{CollectionSchema, DocId, Error, FieldId, Result, Value};
 
 use crate::columns::{KeywordColumn, NumKey, NumericColumn};
-use crate::inverted::{DocPosting, FieldPostings};
+use crate::inverted::DocPosting;
 use crate::memtable::MemTable;
 
 use super::format::{
@@ -99,6 +99,41 @@ fn encode_ids(memtable: &MemTable) -> Result<Vec<u8>> {
 
 // --- postings + terms --------------------------------------------------
 
+/// Fixed number of docs per posting block: small enough that a block's
+/// `max_tf` tracks the true local maximum closely (a tight bound is what
+/// makes block-level pruning worth doing), large enough that the directory
+/// overhead per term stays trivial — a 10,000-doc term needs ~79 blocks ×
+/// 20 bytes ≈ 1.5 KB.
+pub(crate) const POSTING_BLOCK_SIZE: usize = 128;
+
+/// Fixed-width per-block skip metadata: lets a query decide whether to skip
+/// a block, or jump straight to one, without decoding a single posting
+/// inside it. 20 bytes on disk.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BlockMeta {
+    pub last_doc_id: DocId,
+    pub max_tf: u32,
+    /// Absolute byte offset of this block's payload, into the same `.post`
+    /// byte slice `decode_term_field_blocks` was called with.
+    pub offset: u64,
+    pub length: u32,
+}
+
+fn write_block_meta(buf: &mut Vec<u8>, meta: &BlockMeta) {
+    write_u32(buf, meta.last_doc_id);
+    write_u32(buf, meta.max_tf);
+    write_u64(buf, meta.offset);
+    write_u32(buf, meta.length);
+}
+
+fn read_block_meta(cur: &mut Cursor) -> Result<BlockMeta> {
+    let last_doc_id = cur.read_u32()?;
+    let max_tf = cur.read_u32()?;
+    let offset = cur.read_u64()?;
+    let length = cur.read_u32()?;
+    Ok(BlockMeta { last_doc_id, max_tf, offset, length })
+}
+
 fn encode_postings(
     memtable: &MemTable,
     live: &RoaringBitmap,
@@ -150,7 +185,10 @@ fn encode_postings(
     let terms = wrap_fst(TERMS_MAGIC, fst_bytes);
 
     // Postings data, term by term, with an offset table so any one term's
-    // block can be located and decoded without touching the others.
+    // block can be located and decoded without touching the others. Within a
+    // term, each field's postings are further chunked into fixed-size blocks
+    // with their own skip-metadata directory (`BlockMeta`) — see this file's
+    // module doc and `SEGMENT_FORMAT_VERSION`'s doc comment for the shape.
     let mut data = Vec::new();
     let mut offsets = Vec::with_capacity(blocks.len());
     for block in &blocks {
@@ -158,14 +196,42 @@ fn encode_postings(
         write_u32(&mut data, block.fields.len() as u32);
         for (field, docs) in &block.fields {
             write_u32(&mut data, *field as u32);
-            write_u32(&mut data, docs.len() as u32);
-            for posting in docs {
-                write_u32(&mut data, posting.doc_id);
-                write_u32(&mut data, posting.positions.len() as u32);
-                for &p in &posting.positions {
-                    write_u32(&mut data, p);
+            write_u32(&mut data, docs.len() as u32); // doc_freq: O(1) to read back
+
+            let chunks: Vec<&[&DocPosting]> = docs.chunks(POSTING_BLOCK_SIZE).collect();
+            write_u32(&mut data, chunks.len() as u32);
+
+            // Two-pass: build every block's payload bytes into a scratch
+            // buffer first, so each block's own offset (relative to where
+            // this field's payloads begin) is known before its directory
+            // entry is written — the directory precedes the payloads on
+            // disk, so a single forward pass can't know them yet.
+            let mut payloads = Vec::new();
+            let mut metas = Vec::with_capacity(chunks.len());
+            for chunk in &chunks {
+                let start = payloads.len() as u64;
+                write_u32(&mut payloads, chunk.len() as u32);
+                let mut max_tf = 0u32;
+                for posting in *chunk {
+                    write_u32(&mut payloads, posting.doc_id);
+                    write_u32(&mut payloads, posting.positions.len() as u32);
+                    for &p in &posting.positions {
+                        write_u32(&mut payloads, p);
+                    }
+                    max_tf = max_tf.max(posting.positions.len() as u32);
                 }
+                metas.push(BlockMeta {
+                    last_doc_id: chunk.last().expect("chunks() never yields an empty slice").doc_id,
+                    max_tf,
+                    offset: start,
+                    length: (payloads.len() as u64 - start) as u32,
+                });
             }
+
+            for meta in &metas {
+                write_block_meta(&mut data, meta);
+            }
+            data.extend_from_slice(&payloads);
         }
     }
 
@@ -225,94 +291,143 @@ pub(crate) fn decode_post_header(bytes: &[u8]) -> Result<PostHeader> {
 
 const POST_BLOCK_WHAT: &str = "segment postings (term block)";
 
-fn term_block<'a>(bytes: &'a [u8], header: &PostHeader, term_id: u64) -> Result<&'a [u8]> {
-    let term_id = term_id as usize;
-    let start = *header
+/// Absolute byte offset, into `.post`, of term `term_id`'s block.
+fn term_block_start(header: &PostHeader, term_id: u64) -> Result<usize> {
+    header
         .offsets
-        .get(term_id)
-        .ok_or_else(|| Error::corruption(format!("{POST_BLOCK_WHAT}: term id out of range")))?
-        as usize;
-    let end = if term_id + 1 < header.offsets.len() {
-        header.offsets[term_id + 1] as usize
-    } else {
-        bytes.len()
-    };
+        .get(term_id as usize)
+        .map(|&o| o as usize)
+        .ok_or_else(|| Error::corruption(format!("{POST_BLOCK_WHAT}: term id out of range")))
+}
+
+fn term_block<'a>(bytes: &'a [u8], header: &PostHeader, term_id: u64) -> Result<&'a [u8]> {
+    let start = term_block_start(header, term_id)?;
+    let idx = term_id as usize;
+    let end =
+        if idx + 1 < header.offsets.len() { header.offsets[idx + 1] as usize } else { bytes.len() };
     bytes
         .get(start..end)
         .ok_or_else(|| Error::corruption(format!("{POST_BLOCK_WHAT}: offset table out of range")))
 }
 
-/// Decode exactly one term's postings (every field it occurs in), by the
-/// dense id `.terms`' FST maps it to. The only allocation this causes is for
-/// that one term's data — nothing else in the segment is touched.
-pub(crate) fn decode_term_postings(
-    bytes: &[u8],
-    header: &PostHeader,
-    term_id: u64,
-) -> Result<Vec<(FieldId, FieldPostings)>> {
-    let what = POST_BLOCK_WHAT;
-    let block = term_block(bytes, header, term_id)?;
-
-    let mut cur = Cursor::new(block, what);
-    let num_term_fields = cur.read_u32()? as usize;
-    let mut fields = Vec::with_capacity(num_term_fields);
-    for _ in 0..num_term_fields {
-        let field = cur.read_u32()? as FieldId;
-        let num_docs = cur.read_u32()? as usize;
-        let mut docs = Vec::with_capacity(num_docs);
-        for _ in 0..num_docs {
-            let doc_id = cur.read_u32()?;
-            let num_positions = cur.read_u32()? as usize;
-            let mut positions = Vec::with_capacity(num_positions);
-            for _ in 0..num_positions {
-                positions.push(cur.read_u32()?);
-            }
-            docs.push(DocPosting { doc_id, positions });
-        }
-        fields.push((field, FieldPostings { docs }));
-    }
-    Ok(fields)
+/// One (term, field)'s block directory: a doc-frequency count, read once, and
+/// every block's skip metadata — enough to decide which blocks are even
+/// worth decoding, without touching a single posting.
+pub(crate) struct TermFieldBlocks {
+    pub doc_freq: u32,
+    pub blocks: Vec<BlockMeta>,
 }
 
-/// Just the document ids one term occurs in, for one field — no positions
-/// decoded or allocated. `doc_freq`/`live_doc_freq` only ever need a count or
-/// a liveness check, never the positions, and autocomplete calls both across
-/// every candidate term and every source: decoding full posting lists
-/// (positions included) just to answer "how many" would mean paying for data
-/// nobody asked for on the hottest part of that path.
-pub(crate) fn decode_term_field_doc_ids(
+/// Decode one (term, field)'s block directory: `doc_freq` and every block's
+/// `BlockMeta`, with `BlockMeta.offset` already turned into an absolute
+/// offset into `bytes` (the same convention `decode_post_header` uses for its
+/// own top-level term table, one level up). `None` if the term never occurs
+/// in this field. The production entry point for the postings walk — no
+/// posting is decoded here, only the directory that says where they live.
+pub(crate) fn decode_term_field_blocks(
     bytes: &[u8],
     header: &PostHeader,
     term_id: u64,
     field: FieldId,
-) -> Result<Vec<DocId>> {
+) -> Result<Option<TermFieldBlocks>> {
     let what = POST_BLOCK_WHAT;
+    let term_start = term_block_start(header, term_id)?;
     let block = term_block(bytes, header, term_id)?;
 
     let mut cur = Cursor::new(block, what);
     let num_term_fields = cur.read_u32()? as usize;
     for _ in 0..num_term_fields {
         let this_field = cur.read_u32()? as FieldId;
-        let num_docs = cur.read_u32()? as usize;
+        let doc_freq = cur.read_u32()?;
+        let num_blocks = cur.read_u32()? as usize;
+
+        // Every block's metadata is fixed-width and read up front regardless
+        // of whether this is the field being asked about — for a field
+        // that isn't, `BlockMeta.length` is exactly what's needed to skip
+        // its payloads without decoding a single doc inside them.
+        let mut blocks = Vec::with_capacity(num_blocks);
+        let mut payload_len: u64 = 0;
+        for _ in 0..num_blocks {
+            let meta = read_block_meta(&mut cur)?;
+            payload_len += meta.length as u64;
+            blocks.push(meta);
+        }
+
         if this_field != field {
-            // Skip every doc in a field nobody asked about, positions
-            // included — still no allocation, just cursor arithmetic.
-            for _ in 0..num_docs {
-                let _doc_id = cur.read_u32()?;
-                let num_positions = cur.read_u32()? as usize;
-                cur.skip(num_positions * 4)?;
-            }
+            cur.skip(payload_len as usize)?;
             continue;
         }
-        let mut doc_ids = Vec::with_capacity(num_docs);
-        for _ in 0..num_docs {
-            doc_ids.push(cur.read_u32()?);
-            let num_positions = cur.read_u32()? as usize;
-            cur.skip(num_positions * 4)?;
+
+        let payloads_start = (term_start + cur.position()) as u64;
+        for meta in &mut blocks {
+            meta.offset += payloads_start;
         }
-        return Ok(doc_ids);
+        return Ok(Some(TermFieldBlocks { doc_freq, blocks }));
     }
-    Ok(Vec::new())
+    Ok(None)
+}
+
+/// One block's per-doc skeleton — doc ids and term frequencies, decoded
+/// without materializing any positions. `positions_offset[i]` is the absolute
+/// byte offset (into the same `bytes` the block came from) of doc `i`'s
+/// positions, for a lazy read later via [`decode_positions_at`] — paid only
+/// when a document's positions are actually needed (phrase/proximity), never
+/// for a block skipped or only bound-checked.
+pub(crate) struct BlockSkeleton {
+    pub doc_ids: Vec<DocId>,
+    pub tfs: Vec<u32>,
+    pub positions_offsets: Vec<u64>,
+}
+
+pub(crate) fn decode_block_skeleton(bytes: &[u8], meta: &BlockMeta) -> Result<BlockSkeleton> {
+    let what = POST_BLOCK_WHAT;
+    let slice = bytes_at(bytes, meta.offset as usize, meta.length as usize, what)?;
+    let mut cur = Cursor::new(slice, what);
+    let num_docs = cur.read_u32()? as usize;
+    let mut doc_ids = Vec::with_capacity(num_docs);
+    let mut tfs = Vec::with_capacity(num_docs);
+    let mut positions_offsets = Vec::with_capacity(num_docs);
+    for _ in 0..num_docs {
+        doc_ids.push(cur.read_u32()?);
+        let num_positions = cur.read_u32()?;
+        tfs.push(num_positions);
+        positions_offsets.push(meta.offset + cur.position() as u64);
+        cur.skip(num_positions as usize * 4)?;
+    }
+    Ok(BlockSkeleton { doc_ids, tfs, positions_offsets })
+}
+
+/// One document's positions, decoded on demand from an offset
+/// [`decode_block_skeleton`] already located.
+pub(crate) fn decode_positions_at(bytes: &[u8], offset: u64, tf: u32) -> Result<Vec<u32>> {
+    let what = POST_BLOCK_WHAT;
+    let slice = bytes_at(bytes, offset as usize, tf as usize * 4, what)?;
+    let mut cur = Cursor::new(slice, what);
+    let mut positions = Vec::with_capacity(tf as usize);
+    for _ in 0..tf {
+        positions.push(cur.read_u32()?);
+    }
+    Ok(positions)
+}
+
+/// Just the document ids one term occurs in, for one field — no positions
+/// decoded or allocated. `live_doc_freq` needs every doc id (liveness varies
+/// per doc) but never the positions; `doc_freq` itself no longer walks
+/// anything, since [`TermFieldBlocks::doc_freq`] already has the count.
+pub(crate) fn decode_term_field_doc_ids(
+    bytes: &[u8],
+    header: &PostHeader,
+    term_id: u64,
+    field: FieldId,
+) -> Result<Vec<DocId>> {
+    let Some(term_field) = decode_term_field_blocks(bytes, header, term_id, field)? else {
+        return Ok(Vec::new());
+    };
+    let mut doc_ids = Vec::new();
+    for meta in &term_field.blocks {
+        doc_ids.extend(decode_block_skeleton(bytes, meta)?.doc_ids);
+    }
+    Ok(doc_ids)
 }
 
 // --- columns -----------------------------------------------------------
@@ -784,6 +899,8 @@ mod tests {
     use serde_json::json;
     use tachyon_core::{FieldSchema, FieldType, ParsedDocument};
 
+    use crate::inverted::FieldPostings;
+
     fn schema() -> CollectionSchema {
         CollectionSchema::new(
             "products",
@@ -817,6 +934,29 @@ mod tests {
         (m, schema)
     }
 
+    /// Walk every block of one (term, field) and materialize a full
+    /// [`FieldPostings`], positions included — the reference decode every
+    /// block-boundary test below checks the fast, lazy path against.
+    fn decode_term_field_full(
+        post_bytes: &[u8],
+        header: &PostHeader,
+        term_id: u64,
+        field: FieldId,
+    ) -> Option<FieldPostings> {
+        let term_field = decode_term_field_blocks(post_bytes, header, term_id, field).unwrap()?;
+        let mut docs = Vec::new();
+        for meta in &term_field.blocks {
+            let skeleton = decode_block_skeleton(post_bytes, meta).unwrap();
+            for i in 0..skeleton.doc_ids.len() {
+                let positions =
+                    decode_positions_at(post_bytes, skeleton.positions_offsets[i], skeleton.tfs[i])
+                        .unwrap();
+                docs.push(DocPosting { doc_id: skeleton.doc_ids[i], positions });
+            }
+        }
+        Some(FieldPostings { docs })
+    }
+
     fn term_postings(
         terms_bytes: &[u8],
         post_bytes: &[u8],
@@ -826,8 +966,7 @@ mod tests {
         let terms = validate_and_load_fst(terms_bytes, TERMS_MAGIC);
         let term_id = terms.get(term)?;
         let header = decode_post_header(post_bytes).unwrap();
-        let fields = decode_term_postings(post_bytes, &header, term_id).unwrap();
-        fields.into_iter().find(|(f, _)| *f == field).map(|(_, p)| p)
+        decode_term_field_full(post_bytes, &header, term_id, field)
     }
 
     /// Load an `fst::Map` straight from an in-memory encoded blob, skipping
@@ -893,11 +1032,8 @@ mod tests {
 
         for (term, field) in [("mouse", 0u16), ("blue", 1), ("pad", 0)] {
             let term_id = terms.get(term).unwrap();
-            let full = decode_term_postings(&encoded.post, &header, term_id).unwrap();
-            let expected: Vec<DocId> = full
-                .into_iter()
-                .find(|(f, _)| *f == field)
-                .map(|(_, p)| p.docs.iter().map(|d| d.doc_id).collect())
+            let expected: Vec<DocId> = decode_term_field_full(&encoded.post, &header, term_id, field)
+                .map(|p| p.docs.iter().map(|d| d.doc_id).collect())
                 .unwrap_or_default();
 
             let lean = decode_term_field_doc_ids(&encoded.post, &header, term_id, field).unwrap();
@@ -1071,5 +1207,102 @@ mod tests {
         found.sort();
         expected.sort();
         assert_eq!(found, expected);
+    }
+
+    // --- postings block layout ----------------------------------------
+
+    /// `n` documents, each a single-token "mouse" title at position 0 — every
+    /// document occupies exactly one posting, so `n` directly controls how
+    /// many blocks a term spans.
+    fn broad_fixture(n: usize) -> (MemTable, CollectionSchema) {
+        let schema = schema();
+        let mut m = MemTable::new(0, &schema);
+        for i in 0..n {
+            m.insert(doc(&i.to_string(), "mouse", &[], "Brand", i as i64));
+        }
+        (m, schema)
+    }
+
+    #[test]
+    fn a_term_spanning_exactly_n_blocks_has_no_partial_last_block() {
+        let (m, schema) = broad_fixture(POSTING_BLOCK_SIZE * 2);
+        let encoded = encode(&m, &schema).unwrap();
+        let terms = validate_and_load_fst(&encoded.terms, TERMS_MAGIC);
+        let header = decode_post_header(&encoded.post).unwrap();
+        let term_id = terms.get("mouse").unwrap();
+
+        let term_field = decode_term_field_blocks(&encoded.post, &header, term_id, 0).unwrap().unwrap();
+        assert_eq!(term_field.doc_freq, (POSTING_BLOCK_SIZE * 2) as u32);
+        assert_eq!(term_field.blocks.len(), 2, "256 docs at block size 128 is exactly two full blocks");
+        assert_eq!(term_field.blocks[0].last_doc_id, POSTING_BLOCK_SIZE as u32 - 1);
+        assert_eq!(term_field.blocks[1].last_doc_id, POSTING_BLOCK_SIZE as u32 * 2 - 1);
+
+        for meta in &term_field.blocks {
+            let skeleton = decode_block_skeleton(&encoded.post, meta).unwrap();
+            assert_eq!(skeleton.doc_ids.len(), POSTING_BLOCK_SIZE, "no partial last block");
+        }
+    }
+
+    #[test]
+    fn a_term_with_one_doc_past_a_block_boundary_gets_a_singleton_final_block() {
+        let (m, schema) = broad_fixture(POSTING_BLOCK_SIZE + 1);
+        let encoded = encode(&m, &schema).unwrap();
+        let terms = validate_and_load_fst(&encoded.terms, TERMS_MAGIC);
+        let header = decode_post_header(&encoded.post).unwrap();
+        let term_id = terms.get("mouse").unwrap();
+
+        let term_field = decode_term_field_blocks(&encoded.post, &header, term_id, 0).unwrap().unwrap();
+        assert_eq!(term_field.blocks.len(), 2);
+        let first = decode_block_skeleton(&encoded.post, &term_field.blocks[0]).unwrap();
+        let second = decode_block_skeleton(&encoded.post, &term_field.blocks[1]).unwrap();
+        assert_eq!(first.doc_ids.len(), POSTING_BLOCK_SIZE);
+        assert_eq!(second.doc_ids.len(), 1, "the 129th doc gets its own singleton final block");
+        assert_eq!(second.doc_ids[0], POSTING_BLOCK_SIZE as u32);
+        assert_eq!(term_field.blocks[1].last_doc_id, POSTING_BLOCK_SIZE as u32);
+    }
+
+    #[test]
+    fn decoding_across_a_block_boundary_matches_a_hand_built_expectation() {
+        let (m, schema) = broad_fixture(POSTING_BLOCK_SIZE * 2);
+        let encoded = encode(&m, &schema).unwrap();
+        let terms = validate_and_load_fst(&encoded.terms, TERMS_MAGIC);
+        let header = decode_post_header(&encoded.post).unwrap();
+        let term_id = terms.get("mouse").unwrap();
+        let term_field = decode_term_field_blocks(&encoded.post, &header, term_id, 0).unwrap().unwrap();
+
+        // The last doc of block 0 and the first doc of block 1 straddle the
+        // boundary — both must decode correctly from their own block.
+        let block0 = decode_block_skeleton(&encoded.post, &term_field.blocks[0]).unwrap();
+        let block1 = decode_block_skeleton(&encoded.post, &term_field.blocks[1]).unwrap();
+        let last_of_0 = block0.doc_ids.len() - 1;
+
+        assert_eq!(block0.doc_ids[last_of_0], POSTING_BLOCK_SIZE as u32 - 1);
+        assert_eq!(block1.doc_ids[0], POSTING_BLOCK_SIZE as u32);
+
+        let positions_last_of_0 = decode_positions_at(
+            &encoded.post,
+            block0.positions_offsets[last_of_0],
+            block0.tfs[last_of_0],
+        )
+        .unwrap();
+        let positions_first_of_1 =
+            decode_positions_at(&encoded.post, block1.positions_offsets[0], block1.tfs[0]).unwrap();
+        assert_eq!(positions_last_of_0, vec![0], "single-token title: \"mouse\" is always position 0");
+        assert_eq!(positions_first_of_1, vec![0]);
+    }
+
+    #[test]
+    fn skipping_a_field_nobody_asked_for_does_not_touch_its_postings() {
+        // "mouse" occurs in both title (field 0, broad) and, via the fixture
+        // below, nowhere else — this exercises the skip-by-BlockMeta-length
+        // path in `decode_term_field_blocks` for a field that isn't present
+        // at all, which must come back `None` rather than an error.
+        let (m, schema) = broad_fixture(POSTING_BLOCK_SIZE * 2);
+        let encoded = encode(&m, &schema).unwrap();
+        let terms = validate_and_load_fst(&encoded.terms, TERMS_MAGIC);
+        let header = decode_post_header(&encoded.post).unwrap();
+        let term_id = terms.get("mouse").unwrap();
+
+        assert!(decode_term_field_blocks(&encoded.post, &header, term_id, 1).unwrap().is_none());
     }
 }

--- a/crates/tachyon-index/src/segment/codec.rs
+++ b/crates/tachyon-index/src/segment/codec.rs
@@ -1032,9 +1032,10 @@ mod tests {
 
         for (term, field) in [("mouse", 0u16), ("blue", 1), ("pad", 0)] {
             let term_id = terms.get(term).unwrap();
-            let expected: Vec<DocId> = decode_term_field_full(&encoded.post, &header, term_id, field)
-                .map(|p| p.docs.iter().map(|d| d.doc_id).collect())
-                .unwrap_or_default();
+            let expected: Vec<DocId> =
+                decode_term_field_full(&encoded.post, &header, term_id, field)
+                    .map(|p| p.docs.iter().map(|d| d.doc_id).collect())
+                    .unwrap_or_default();
 
             let lean = decode_term_field_doc_ids(&encoded.post, &header, term_id, field).unwrap();
             assert_eq!(lean, expected, "term {term:?} field {field}");
@@ -1231,9 +1232,14 @@ mod tests {
         let header = decode_post_header(&encoded.post).unwrap();
         let term_id = terms.get("mouse").unwrap();
 
-        let term_field = decode_term_field_blocks(&encoded.post, &header, term_id, 0).unwrap().unwrap();
+        let term_field =
+            decode_term_field_blocks(&encoded.post, &header, term_id, 0).unwrap().unwrap();
         assert_eq!(term_field.doc_freq, (POSTING_BLOCK_SIZE * 2) as u32);
-        assert_eq!(term_field.blocks.len(), 2, "256 docs at block size 128 is exactly two full blocks");
+        assert_eq!(
+            term_field.blocks.len(),
+            2,
+            "256 docs at block size 128 is exactly two full blocks"
+        );
         assert_eq!(term_field.blocks[0].last_doc_id, POSTING_BLOCK_SIZE as u32 - 1);
         assert_eq!(term_field.blocks[1].last_doc_id, POSTING_BLOCK_SIZE as u32 * 2 - 1);
 
@@ -1251,7 +1257,8 @@ mod tests {
         let header = decode_post_header(&encoded.post).unwrap();
         let term_id = terms.get("mouse").unwrap();
 
-        let term_field = decode_term_field_blocks(&encoded.post, &header, term_id, 0).unwrap().unwrap();
+        let term_field =
+            decode_term_field_blocks(&encoded.post, &header, term_id, 0).unwrap().unwrap();
         assert_eq!(term_field.blocks.len(), 2);
         let first = decode_block_skeleton(&encoded.post, &term_field.blocks[0]).unwrap();
         let second = decode_block_skeleton(&encoded.post, &term_field.blocks[1]).unwrap();
@@ -1268,7 +1275,8 @@ mod tests {
         let terms = validate_and_load_fst(&encoded.terms, TERMS_MAGIC);
         let header = decode_post_header(&encoded.post).unwrap();
         let term_id = terms.get("mouse").unwrap();
-        let term_field = decode_term_field_blocks(&encoded.post, &header, term_id, 0).unwrap().unwrap();
+        let term_field =
+            decode_term_field_blocks(&encoded.post, &header, term_id, 0).unwrap().unwrap();
 
         // The last doc of block 0 and the first doc of block 1 straddle the
         // boundary — both must decode correctly from their own block.
@@ -1287,7 +1295,11 @@ mod tests {
         .unwrap();
         let positions_first_of_1 =
             decode_positions_at(&encoded.post, block1.positions_offsets[0], block1.tfs[0]).unwrap();
-        assert_eq!(positions_last_of_0, vec![0], "single-token title: \"mouse\" is always position 0");
+        assert_eq!(
+            positions_last_of_0,
+            vec![0],
+            "single-token title: \"mouse\" is always position 0"
+        );
         assert_eq!(positions_first_of_1, vec![0]);
     }
 

--- a/crates/tachyon-index/src/segment/cursor.rs
+++ b/crates/tachyon-index/src/segment/cursor.rs
@@ -131,7 +131,10 @@ mod tests {
     fn schema() -> CollectionSchema {
         CollectionSchema::new(
             "products",
-            vec![FieldSchema::new("title", FieldType::Text), FieldSchema::new("tags", FieldType::Text)],
+            vec![
+                FieldSchema::new("title", FieldType::Text),
+                FieldSchema::new("tags", FieldType::Text),
+            ],
         )
     }
 
@@ -155,10 +158,16 @@ mod tests {
         (m, schema)
     }
 
-    fn open_cursor<'a>(post: &'a [u8], terms: &fst::Map<Vec<u8>>, term: &str, field: u16) -> SegmentPostingCursor<'a> {
+    fn open_cursor<'a>(
+        post: &'a [u8],
+        terms: &fst::Map<Vec<u8>>,
+        term: &str,
+        field: u16,
+    ) -> SegmentPostingCursor<'a> {
         let header = decode_post_header(post).unwrap();
         let term_id = terms.get(term).unwrap();
-        let term_field = codec::decode_term_field_blocks(post, &header, term_id, field).unwrap().unwrap();
+        let term_field =
+            codec::decode_term_field_blocks(post, &header, term_id, field).unwrap().unwrap();
         SegmentPostingCursor::new(post, term_field)
     }
 

--- a/crates/tachyon-index/src/segment/cursor.rs
+++ b/crates/tachyon-index/src/segment/cursor.rs
@@ -1,0 +1,236 @@
+//! A [`PostingCursor`] over one (term, field)'s postings in a segment.
+//!
+//! Only the currently active block's skeleton — doc ids and term
+//! frequencies, positions skipped — is ever decoded, from the segment's
+//! mmap'd `.post` bytes; a fresh decode happens only when the cursor
+//! actually crosses into a new block, whether by plain `advance` or by an
+//! `advance_to` jump that lands elsewhere in the directory.
+
+use tachyon_core::DocId;
+
+use crate::cursor::PostingCursor;
+
+use super::codec::{self, BlockMeta, BlockSkeleton, TermFieldBlocks};
+
+pub(crate) struct SegmentPostingCursor<'a> {
+    bytes: &'a [u8],
+    blocks: Vec<BlockMeta>,
+    /// Always `<= blocks.len()`; `blocks.len()` means exhausted.
+    block_idx: usize,
+    /// `None` when `block_idx` is out of range, or a block failed to
+    /// decode — corrupt segment bytes surface as an exhausted cursor rather
+    /// than a panic, the same policy every other segment reader in this
+    /// crate follows.
+    skeleton: Option<BlockSkeleton>,
+    doc_idx: usize,
+}
+
+impl<'a> SegmentPostingCursor<'a> {
+    /// `term_field`'s block directory is consumed into the cursor; nothing
+    /// beyond the first block's skeleton is decoded yet.
+    pub(crate) fn new(bytes: &'a [u8], term_field: TermFieldBlocks) -> SegmentPostingCursor<'a> {
+        let mut cursor = SegmentPostingCursor {
+            bytes,
+            blocks: term_field.blocks,
+            block_idx: 0,
+            skeleton: None,
+            doc_idx: 0,
+        };
+        cursor.load_block(0);
+        cursor
+    }
+
+    fn load_block(&mut self, idx: usize) {
+        self.block_idx = idx.min(self.blocks.len());
+        self.doc_idx = 0;
+        self.skeleton = match self.blocks.get(self.block_idx) {
+            Some(meta) => match codec::decode_block_skeleton(self.bytes, meta) {
+                Ok(skeleton) => Some(skeleton),
+                Err(e) => {
+                    tracing::warn!(error = %e, "segment: failed to decode a posting block");
+                    None
+                }
+            },
+            None => None,
+        };
+    }
+}
+
+impl PostingCursor for SegmentPostingCursor<'_> {
+    fn doc_id(&self) -> Option<DocId> {
+        self.skeleton.as_ref()?.doc_ids.get(self.doc_idx).copied()
+    }
+
+    fn term_freq(&self) -> u32 {
+        self.skeleton.as_ref().and_then(|s| s.tfs.get(self.doc_idx)).copied().unwrap_or(0)
+    }
+
+    fn positions(&self) -> Vec<u32> {
+        let Some(skeleton) = &self.skeleton else { return Vec::new() };
+        let (Some(&offset), Some(&tf)) =
+            (skeleton.positions_offsets.get(self.doc_idx), skeleton.tfs.get(self.doc_idx))
+        else {
+            return Vec::new();
+        };
+        codec::decode_positions_at(self.bytes, offset, tf).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "segment: failed to decode posting positions");
+            Vec::new()
+        })
+    }
+
+    fn advance(&mut self) -> Option<DocId> {
+        let len = self.skeleton.as_ref().map_or(0, |s| s.doc_ids.len());
+        if self.doc_idx + 1 < len {
+            self.doc_idx += 1;
+        } else {
+            self.load_block(self.block_idx + 1);
+        }
+        self.doc_id()
+    }
+
+    fn advance_to(&mut self, target: DocId) -> Option<DocId> {
+        // Inside the currently loaded block: a plain binary search.
+        if let Some(skeleton) = &self.skeleton {
+            if skeleton.doc_ids.last().is_some_and(|&last| last >= target) {
+                self.doc_idx += skeleton.doc_ids[self.doc_idx..].partition_point(|&d| d < target);
+                return self.doc_id();
+            }
+        }
+
+        // Otherwise, binary-search the block directory by `last_doc_id` and
+        // jump straight to the one block that could hold `target`, without
+        // ever decoding the blocks in between.
+        let jump = self.blocks[self.block_idx..].partition_point(|b| b.last_doc_id < target);
+        self.load_block(self.block_idx + jump);
+        if let Some(skeleton) = &self.skeleton {
+            self.doc_idx = skeleton.doc_ids.partition_point(|&d| d < target);
+        }
+        self.doc_id()
+    }
+
+    fn max_remaining_tf(&self) -> u32 {
+        self.blocks.get(self.block_idx).map_or(0, |b| b.max_tf)
+    }
+
+    fn current_block_last_doc_id(&self) -> Option<DocId> {
+        self.blocks.get(self.block_idx).map(|b| b.last_doc_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tachyon_core::{CollectionSchema, FieldSchema, FieldType, ParsedDocument};
+
+    use crate::memtable::MemTable;
+    use crate::segment::format::TERMS_MAGIC;
+
+    use codec::{decode_post_header, POSTING_BLOCK_SIZE};
+
+    fn schema() -> CollectionSchema {
+        CollectionSchema::new(
+            "products",
+            vec![FieldSchema::new("title", FieldType::Text), FieldSchema::new("tags", FieldType::Text)],
+        )
+    }
+
+    /// `n` documents; doc `i` matches "mouse" in `title` only when `i` is
+    /// even, at position 0 — a sparse posting list with real gaps in doc id,
+    /// so `advance_to` has genuinely absent ids to be tested against, not
+    /// just present ones.
+    fn sparse_fixture(n: usize) -> (MemTable, CollectionSchema) {
+        let schema = schema();
+        let mut m = MemTable::new(0, &schema);
+        for i in 0..n {
+            let title = if i % 2 == 0 { "mouse" } else { "keyboard" };
+            m.insert(
+                ParsedDocument::parse(
+                    json!({ "id": i.to_string(), "title": title, "tags": [] }),
+                    &schema,
+                )
+                .unwrap(),
+            );
+        }
+        (m, schema)
+    }
+
+    fn open_cursor<'a>(post: &'a [u8], terms: &fst::Map<Vec<u8>>, term: &str, field: u16) -> SegmentPostingCursor<'a> {
+        let header = decode_post_header(post).unwrap();
+        let term_id = terms.get(term).unwrap();
+        let term_field = codec::decode_term_field_blocks(post, &header, term_id, field).unwrap().unwrap();
+        SegmentPostingCursor::new(post, term_field)
+    }
+
+    fn load_fst(bytes: &[u8]) -> fst::Map<Vec<u8>> {
+        let start = codec::validate_header(bytes, TERMS_MAGIC, "test fst").unwrap();
+        fst::Map::new(bytes[start..].to_vec()).unwrap()
+    }
+
+    #[test]
+    fn agrees_with_a_plain_linear_reference_walk_across_multiple_blocks() {
+        let n = POSTING_BLOCK_SIZE * 4; // 256 "mouse" postings: doc ids 0, 2, .., 510
+        let (m, schema) = sparse_fixture(n);
+        let encoded = super::super::encode(&m, &schema).unwrap();
+        let terms = load_fst(&encoded.terms);
+
+        let expected: Vec<(DocId, u32, Vec<u32>)> = m
+            .index()
+            .postings("mouse", 0)
+            .unwrap()
+            .docs
+            .iter()
+            .map(|d| (d.doc_id, d.tf(), d.positions.clone()))
+            .collect();
+        assert_eq!(expected.len(), n / 2, "sanity: every even doc contains \"mouse\"");
+
+        let mut cursor = open_cursor(&encoded.post, &terms, "mouse", 0);
+        let mut got = Vec::new();
+        while let Some(doc_id) = cursor.doc_id() {
+            got.push((doc_id, cursor.term_freq(), cursor.positions()));
+            cursor.advance();
+        }
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn advance_to_is_correct_at_and_around_a_block_boundary() {
+        let n = POSTING_BLOCK_SIZE * 4;
+        let (m, schema) = sparse_fixture(n);
+        let encoded = super::super::encode(&m, &schema).unwrap();
+        let terms = load_fst(&encoded.terms);
+        let header = decode_post_header(&encoded.post).unwrap();
+        let term_id = terms.get("mouse").unwrap();
+        let term_field =
+            codec::decode_term_field_blocks(&encoded.post, &header, term_id, 0).unwrap().unwrap();
+        assert_eq!(term_field.blocks.len(), 2, "256 postings at block size 128 is two full blocks");
+        let block0_last = term_field.blocks[0].last_doc_id; // 254 (128th even id, 0-indexed)
+
+        // Exact last doc id of block 0.
+        let mut cursor = open_cursor(&encoded.post, &terms, "mouse", 0);
+        assert_eq!(cursor.advance_to(block0_last), Some(block0_last));
+        assert_eq!(cursor.current_block_last_doc_id(), Some(block0_last), "still inside block 0");
+
+        // An id absent from both blocks (odd, between the two boundaries)
+        // must land on the next real doc, which is block 1's first.
+        let mut cursor = open_cursor(&encoded.post, &terms, "mouse", 0);
+        let landed = cursor.advance_to(block0_last + 1).unwrap();
+        assert_eq!(landed, block0_last + 2, "the next even doc id, now inside block 1");
+        assert_eq!(cursor.current_block_last_doc_id(), Some(term_field.blocks[1].last_doc_id));
+
+        // Exact first doc id of block 1.
+        let mut cursor = open_cursor(&encoded.post, &terms, "mouse", 0);
+        assert_eq!(cursor.advance_to(block0_last + 2), Some(block0_last + 2));
+
+        // A target inside a block's own range but absent (odd id) lands on
+        // the next present doc within that same block.
+        let mut cursor = open_cursor(&encoded.post, &terms, "mouse", 0);
+        assert_eq!(cursor.advance_to(101), Some(102));
+
+        // Past every doc id: exhausts without panicking.
+        let mut cursor = open_cursor(&encoded.post, &terms, "mouse", 0);
+        assert_eq!(cursor.advance_to(n as DocId + 1000), None);
+        assert_eq!(cursor.advance_to(0), None, "stays exhausted");
+        assert_eq!(cursor.advance(), None, "and never panics on a further advance");
+    }
+}

--- a/crates/tachyon-index/src/segment/format.rs
+++ b/crates/tachyon-index/src/segment/format.rs
@@ -9,11 +9,12 @@
 
 use tachyon_core::{Error, Result};
 
-/// v2: postings, columns, and the document store are read lazily from mmap'd
-/// files via offset tables instead of being fully decoded at open time. v1
-/// segments are not readable by this build — same policy as a tokenizer
-/// change, which also invalidates existing segments.
-pub const SEGMENT_FORMAT_VERSION: u32 = 2;
+/// v3: `.post` postings are grouped into fixed-size blocks with per-block
+/// skip metadata (max doc id, max term frequency, byte offset/length), so a
+/// query can skip a block — or jump straight to one — without decoding the
+/// blocks in between. v1/v2 segments are not readable by this build — same
+/// policy as a tokenizer change, which also invalidates existing segments.
+pub const SEGMENT_FORMAT_VERSION: u32 = 3;
 
 /// Byte length of every segment file's header (8-byte magic + 4-byte version).
 pub const HEADER_LEN: usize = 12;

--- a/crates/tachyon-index/src/segment/mod.rs
+++ b/crates/tachyon-index/src/segment/mod.rs
@@ -10,6 +10,7 @@
 //! decodes them on demand.
 
 mod codec;
+mod cursor;
 mod format;
 mod reader;
 

--- a/crates/tachyon-index/src/segment/reader.rs
+++ b/crates/tachyon-index/src/segment/reader.rs
@@ -20,11 +20,12 @@ use serde_json::Value as Json;
 use tachyon_core::{CollectionSchema, DocId, Error, FieldId, Result, Value};
 
 use crate::columns::{KeywordColumn, NumericColumn};
+use crate::cursor::PostingCursor;
 use crate::fuzzy::FuzzyMatcher;
-use crate::inverted::FieldPostings;
 use crate::source::IndexSource;
 
 use super::codec::{self, ColHeader, DocHeader, PostHeader};
+use super::cursor::SegmentPostingCursor;
 use super::format::{HEADER_LEN, IDS_MAGIC, TERMS_MAGIC};
 
 /// The five files one segment is stored as.
@@ -175,10 +176,13 @@ impl IndexSource for SegmentReader {
         }
     }
 
-    fn postings(&self, term: &str, field: FieldId) -> Option<Cow<'_, FieldPostings>> {
+    fn posting_cursor(&self, term: &str, field: FieldId) -> Option<Box<dyn PostingCursor + '_>> {
         let term_id = self.terms.get(term)?;
-        match codec::decode_term_postings(&self.post, &self.post_header, term_id) {
-            Ok(fields) => fields.into_iter().find(|(f, _)| *f == field).map(|(_, p)| Cow::Owned(p)),
+        match codec::decode_term_field_blocks(&self.post, &self.post_header, term_id, field) {
+            Ok(Some(term_field)) => {
+                Some(Box::new(SegmentPostingCursor::new(&self.post, term_field)) as Box<dyn PostingCursor + '_>)
+            }
+            Ok(None) => None,
             Err(e) => {
                 tracing::warn!(term, field, error = %e, "segment: failed to decode postings");
                 None
@@ -187,18 +191,18 @@ impl IndexSource for SegmentReader {
     }
 
     // Overridden rather than left to the trait's default (which goes through
-    // `postings()`): both only ever need doc ids, never positions, and
+    // `posting_cursor()`): both only ever need doc ids, never positions, and
     // autocomplete calls these across every candidate term and every source.
-    // Decoding — and allocating — full posting lists including positions just
-    // to count them would make the cheap common case pay for data nobody
-    // asked for.
+    // `doc_freq` in particular is a stored count (O(1) once the term's block
+    // directory is located), not a walk.
 
     fn doc_freq(&self, term: &str, field: FieldId) -> u32 {
         let Some(term_id) = self.terms.get(term) else { return 0 };
-        match codec::decode_term_field_doc_ids(&self.post, &self.post_header, term_id, field) {
-            Ok(doc_ids) => doc_ids.len() as u32,
+        match codec::decode_term_field_blocks(&self.post, &self.post_header, term_id, field) {
+            Ok(Some(term_field)) => term_field.doc_freq,
+            Ok(None) => 0,
             Err(e) => {
-                tracing::warn!(term, field, error = %e, "segment: failed to decode doc ids");
+                tracing::warn!(term, field, error = %e, "segment: failed to decode postings");
                 0
             }
         }
@@ -363,22 +367,29 @@ mod tests {
             }
         }
 
+        // Drain a source's cursor into the same `(doc_id, positions)` shape
+        // `posting_cursor()` promises, one `advance()` at a time — the
+        // comparable shape both `mem`/`seg` are checked against below.
+        fn drain(source: &dyn IndexSource, term: &str, field: FieldId) -> Option<Vec<(u32, Vec<u32>)>> {
+            let mut cursor = source.posting_cursor(term, field)?;
+            let mut out = Vec::new();
+            while let Some(doc_id) = cursor.doc_id() {
+                out.push((doc_id, cursor.positions()));
+                cursor.advance();
+            }
+            Some(out)
+        }
+
         for term in ["mouse", "wireless", "pad", "blue", "red", "keyboard", "nope"] {
             for field in [0u16, 1] {
                 // The memtable's postings still carry the hole until a
                 // flush; a segment never does. Filter to what the memtable
                 // itself considers live before comparing.
-                let mem_docs: Option<Vec<(u32, Vec<u32>)>> = mem.postings(term, field).map(|p| {
-                    p.docs
-                        .iter()
-                        .filter(|d| mem.is_live(d.doc_id))
-                        .map(|d| (d.doc_id, d.positions.clone()))
-                        .collect()
+                let mem_docs = drain(mem, term, field).map(|docs| {
+                    docs.into_iter().filter(|(doc_id, _)| mem.is_live(*doc_id)).collect::<Vec<_>>()
                 });
                 let mem_docs = mem_docs.filter(|d| !d.is_empty());
-                let seg_docs: Option<Vec<(u32, Vec<u32>)>> = seg
-                    .postings(term, field)
-                    .map(|p| p.docs.iter().map(|d| (d.doc_id, d.positions.clone())).collect());
+                let seg_docs = drain(seg, term, field);
                 assert_eq!(mem_docs, seg_docs, "term {term:?} field {field}");
 
                 // doc_freq/live_doc_freq go through a separate, positions-free

--- a/crates/tachyon-index/src/segment/reader.rs
+++ b/crates/tachyon-index/src/segment/reader.rs
@@ -180,7 +180,8 @@ impl IndexSource for SegmentReader {
         let term_id = self.terms.get(term)?;
         match codec::decode_term_field_blocks(&self.post, &self.post_header, term_id, field) {
             Ok(Some(term_field)) => {
-                Some(Box::new(SegmentPostingCursor::new(&self.post, term_field)) as Box<dyn PostingCursor + '_>)
+                Some(Box::new(SegmentPostingCursor::new(&self.post, term_field))
+                    as Box<dyn PostingCursor + '_>)
             }
             Ok(None) => None,
             Err(e) => {
@@ -370,7 +371,11 @@ mod tests {
         // Drain a source's cursor into the same `(doc_id, positions)` shape
         // `posting_cursor()` promises, one `advance()` at a time — the
         // comparable shape both `mem`/`seg` are checked against below.
-        fn drain(source: &dyn IndexSource, term: &str, field: FieldId) -> Option<Vec<(u32, Vec<u32>)>> {
+        fn drain(
+            source: &dyn IndexSource,
+            term: &str,
+            field: FieldId,
+        ) -> Option<Vec<(u32, Vec<u32>)>> {
             let mut cursor = source.posting_cursor(term, field)?;
             let mut out = Vec::new();
             while let Some(doc_id) = cursor.doc_id() {

--- a/crates/tachyon-index/src/source.rs
+++ b/crates/tachyon-index/src/source.rs
@@ -9,16 +9,20 @@
 //!
 //! # Borrowed vs. owned
 //!
-//! Every method that hands back index data returns [`Cow`] rather than a bare
-//! reference. The memtable's data already lives in memory in exactly the
+//! Every method that hands back a whole value returns [`Cow`] rather than a
+//! bare reference. The memtable's data already lives in memory in exactly the
 //! shape callers want, so it returns `Cow::Borrowed` at zero cost — nothing
 //! about the memtable's performance changes. A segment, however, keeps almost
-//! nothing decoded at rest: its postings, columns, and document values are
-//! read from an mmap'd file and decoded into an owned value only when asked
-//! for, which is what keeps a segment's resident memory bounded by corpus
-//! size rather than by how much of it has ever been queried. `Cow` lets one
-//! trait describe both without forcing the memtable to pay a clone it never
-//! needed.
+//! nothing decoded at rest: its columns and document values are read from an
+//! mmap'd file and decoded into an owned value only when asked for, which is
+//! what keeps a segment's resident memory bounded by corpus size rather than
+//! by how much of it has ever been queried. `Cow` lets one trait describe
+//! both without forcing the memtable to pay a clone it never needed.
+//!
+//! Postings are the one exception: [`IndexSource::posting_cursor`] hands back
+//! a `Box<dyn PostingCursor>` rather than a `Cow`, since even a segment's
+//! *whole* posting list is never materialized — a cursor decodes one block at
+//! a time, lazily, regardless of which source it reads from.
 
 use std::borrow::Cow;
 
@@ -27,8 +31,8 @@ use roaring::RoaringBitmap;
 use tachyon_core::{DocId, FieldId, Value};
 
 use crate::columns::{KeywordColumn, NumericColumn};
+use crate::cursor::{MemTablePostingCursor, PostingCursor};
 use crate::fuzzy::FuzzyMatcher;
-use crate::inverted::FieldPostings;
 use crate::memtable::MemTable;
 
 pub trait IndexSource: Send + Sync {
@@ -49,12 +53,22 @@ pub trait IndexSource: Send + Sync {
     /// The keyword filter/facet column for a field, if it has one.
     fn keyword_column(&self, field: FieldId) -> Option<Cow<'_, KeywordColumn>>;
 
-    /// Postings for a term in a field, or `None` if absent.
-    fn postings(&self, term: &str, field: FieldId) -> Option<Cow<'_, FieldPostings>>;
+    /// A lazy, doc-at-a-time cursor over a term's postings in a field, or
+    /// `None` if absent. The query engine's pruning walk reads postings
+    /// exclusively through this — never materializing a term's full posting
+    /// list — so a document a sound bound proves unnecessary is never
+    /// decoded at all, not merely scored cheaply.
+    fn posting_cursor(&self, term: &str, field: FieldId) -> Option<Box<dyn PostingCursor + '_>>;
 
     /// Documents in this source containing `term` in `field`.
     fn doc_freq(&self, term: &str, field: FieldId) -> u32 {
-        self.postings(term, field).map_or(0, |p| p.doc_freq())
+        let Some(mut cursor) = self.posting_cursor(term, field) else { return 0 };
+        let mut count = 0u32;
+        while cursor.doc_id().is_some() {
+            count += 1;
+            cursor.advance();
+        }
+        count
     }
 
     /// Documents containing `term` in `field` that are still live.
@@ -64,14 +78,15 @@ pub trait IndexSource: Send + Sync {
     /// property until a merge — but anything user-facing, such as an
     /// autocomplete count, must not promise results that no longer exist.
     fn live_doc_freq(&self, term: &str, field: FieldId, deleted: &RoaringBitmap) -> u64 {
-        let Some(postings) = self.postings(term, field) else {
-            return 0;
-        };
-        postings
-            .docs
-            .iter()
-            .filter(|posting| self.is_live(posting.doc_id) && !deleted.contains(posting.doc_id))
-            .count() as u64
+        let Some(mut cursor) = self.posting_cursor(term, field) else { return 0 };
+        let mut count = 0u64;
+        while let Some(doc_id) = cursor.doc_id() {
+            if self.is_live(doc_id) && !deleted.contains(doc_id) {
+                count += 1;
+            }
+            cursor.advance();
+        }
+        count
     }
 
     /// Documents in this source with any content in `field`. Summed across
@@ -128,8 +143,10 @@ impl IndexSource for MemTable {
         MemTable::columns(self).keyword(field).map(Cow::Borrowed)
     }
 
-    fn postings(&self, term: &str, field: FieldId) -> Option<Cow<'_, FieldPostings>> {
-        self.index().postings(term, field).map(Cow::Borrowed)
+    fn posting_cursor(&self, term: &str, field: FieldId) -> Option<Box<dyn PostingCursor + '_>> {
+        self.index()
+            .postings(term, field)
+            .map(|p| Box::new(MemTablePostingCursor::new(&p.docs)) as Box<dyn PostingCursor + '_>)
     }
 
     fn doc_freq(&self, term: &str, field: FieldId) -> u32 {

--- a/crates/tachyon-query/src/bm25.rs
+++ b/crates/tachyon-query/src/bm25.rs
@@ -56,6 +56,20 @@ pub fn term_score(tf: u32, field_len: u32, stats: FieldStats, idf: f32) -> f32 {
     idf * (tf * (K1 + 1.0)) / (tf + K1 * length_norm)
 }
 
+/// Upper bound on [`term_score`] for any document, given only a block's max
+/// term frequency. `length_norm`'s minimum is `1 - B` (as `field_len -> 0`),
+/// and `term_score` is non-increasing in `length_norm` and non-decreasing in
+/// `tf`, so evaluating at that floor is sound regardless of the actual field
+/// length of any document a block holds. Converges to `idf * (K1 + 1.0)` as
+/// `max_tf -> infinity`, the same ceiling `term_frequency_saturates` checks.
+pub fn term_score_bound(max_tf: u32, idf: f32) -> f32 {
+    if max_tf == 0 {
+        return 0.0;
+    }
+    let tf = max_tf as f32;
+    idf * (tf * (K1 + 1.0)) / (tf + K1 * (1.0 - B))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -124,5 +138,37 @@ mod tests {
     fn field_stats_average() {
         assert_eq!(FieldStats::new(4, 40).avg_len, 10.0);
         assert_eq!(FieldStats::new(0, 0).avg_len, 0.0);
+    }
+
+    #[test]
+    fn term_score_bound_is_a_sound_ceiling() {
+        let idf = idf(10, 100);
+        for &max_tf in &[1, 2, 5, 10, 50, 1_000] {
+            let bound = term_score_bound(max_tf, idf);
+            for &avg_len in &[1.0f32, 5.0, 10.0, 50.0, 200.0] {
+                let stats = FieldStats::new(100, (avg_len * 100.0) as u64);
+                for &field_len in &[1u32, 3, 10, 50, 500] {
+                    for &tf in &[1u32, max_tf] {
+                        let actual = term_score(tf, field_len, stats, idf);
+                        assert!(
+                            actual <= bound + 1e-6,
+                            "tf={tf} field_len={field_len} avg_len={avg_len}: actual {actual} exceeded bound {bound}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn term_score_bound_converges_to_the_same_ceiling_as_unbounded_tf() {
+        let idf = idf(10, 100);
+        let bound = term_score_bound(10_000_000, idf);
+        assert!((bound - idf * (K1 + 1.0)).abs() < 1e-3, "got {bound}");
+    }
+
+    #[test]
+    fn term_score_bound_of_zero_tf_is_zero() {
+        assert_eq!(term_score_bound(0, 1.0), 0.0);
     }
 }

--- a/crates/tachyon-query/src/executor.rs
+++ b/crates/tachyon-query/src/executor.rs
@@ -204,7 +204,8 @@ pub fn execute(ctx: &SearchContext, req: &SearchRequest) -> SearchOutcome {
         .is_none_or(|clauses| clauses.first().is_some_and(|c| c.key == SortKey::TextMatch));
 
     let mut frontiers = wand::build_frontiers(ctx, req, &expansions);
-    let scorer = wand::DocScorer::new(ctx, req, filter, allowed_edits, needs_positions, tokens.len());
+    let scorer =
+        wand::DocScorer::new(ctx, req, filter, allowed_edits, needs_positions, tokens.len());
     let mut top_k = prunable.then(|| TopKByScore::new(req.window()));
     let mut candidates: Vec<Ranked> = Vec::new(); // used only when `top_k` is None
 
@@ -284,8 +285,8 @@ impl TopKByScore {
             return;
         }
         let Some(worst) = self.heap.peek() else { return };
-        let replaces =
-            ranked.score > worst.0.score || (ranked.score == worst.0.score && ranked.doc_id < worst.0.doc_id);
+        let replaces = ranked.score > worst.0.score
+            || (ranked.score == worst.0.score && ranked.doc_id < worst.0.doc_id);
         if replaces {
             self.heap.pop();
             self.heap.push(ScoredEntry(ranked));
@@ -1362,7 +1363,10 @@ mod tests {
                 ..Default::default()
             });
             assert_eq!(out.found, 250, "mode {mode}: every kept/tail document contains \"mouse\"");
-            assert!(out.found_is_exact, "mode {mode}: a full window must never leave found_is_exact false");
+            assert!(
+                out.found_is_exact,
+                "mode {mode}: a full window must never leave found_is_exact false"
+            );
         }
     }
 
@@ -1393,7 +1397,10 @@ mod tests {
             ..Default::default()
         });
 
-        assert_eq!(large.found, 250, "the reference run is unpruned: every kept/tail doc contains \"mouse\"");
+        assert_eq!(
+            large.found, 250,
+            "the reference run is unpruned: every kept/tail doc contains \"mouse\""
+        );
         assert!(large.found_is_exact);
 
         assert!(!small.found_is_exact, "a genuinely hopeless block must have been skipped");
@@ -1622,8 +1629,14 @@ mod tests {
 
         for doc_id in 0..5 {
             assert!(ctx.is_live(doc_id), "doc {doc_id} is live in the second, real-owning source");
-            assert!(ctx.field_len(doc_id, 0) > 0, "doc {doc_id}'s length must come from the real owner");
-            assert!(ctx.value(doc_id, 0).is_some(), "doc {doc_id}'s value must come from the real owner");
+            assert!(
+                ctx.field_len(doc_id, 0) > 0,
+                "doc {doc_id}'s length must come from the real owner"
+            );
+            assert!(
+                ctx.value(doc_id, 0).is_some(),
+                "doc {doc_id}'s value must come from the real owner"
+            );
         }
 
         let req = SearchRequest::resolve(
@@ -1683,7 +1696,10 @@ mod tests {
                 limit: Some(5),
                 ..Default::default()
             });
-            assert!(!out.found_is_exact, "mode {mode}: a window-filling query that genuinely skips");
+            assert!(
+                !out.found_is_exact,
+                "mode {mode}: a window-filling query that genuinely skips"
+            );
         }
     }
 }

--- a/crates/tachyon-query/src/executor.rs
+++ b/crates/tachyon-query/src/executor.rs
@@ -1,11 +1,25 @@
-//! Search execution: expand the query, walk the postings, score, take top-K.
+//! Search execution: expand the query, then hand the walk itself to
+//! `wand.rs`.
 //!
 //! # Shape of a search
 //!
 //! ```text
-//! q -> tokens -> per-token candidate terms -> postings walk
-//!   -> flat per-(document, field, token) accumulator -> composite score -> page
+//! q -> tokens -> per-token candidate terms -> wand::build_frontiers
+//!   -> wand::run_disjunctive / run_conjunctive -> page
 //! ```
+//!
+//! # Two pruning mechanisms, composed
+//!
+//! `wand.rs`'s drivers ("true WAND") decide which documents are worth
+//! resolving at all, skipping whole blocks — sometimes whole documents —
+//! when a sound bound proves they cannot affect the top-K; that's the only
+//! source of approximation (`SearchOutcome::found_is_exact`). A document
+//! that *is* resolved still passes through the older "scoped" mechanism
+//! inside `wand::DocScorer::score`: a real, exact per-field BM25 sum (not a
+//! bound — the document was already resolved) gates the expensive tail —
+//! proximity, the popularity read, `combine()` — the same way it always
+//! has. That mechanism never causes approximation; it only ever decides
+//! how much of an already-counted match's scoring to skip.
 //!
 //! # Multi-field scoring
 //!
@@ -15,76 +29,28 @@
 //! field" is chosen by boosted BM25, and that same field supplies the
 //! proximity and typo signals, so all five PRD §12 components describe the
 //! same match rather than a blend of unrelated ones.
-//!
-//! # Why the accumulator is flat
-//!
-//! A broad query on a large collection matches a large fraction of the corpus,
-//! and every match has to be scored. The obvious structure — a map from doc id
-//! to a struct holding a vector per field per token — allocates several times
-//! per matched document, and at a hundred thousand matches that allocation
-//! traffic dominates the query.
-//!
-//! So the evidence lives in flat vectors addressed arithmetically by
-//! `(slot, field, token)`. A newly matched document appends one block; nothing
-//! else allocates.
 
 use std::borrow::Cow;
 use std::cmp::Ordering;
+use std::collections::BinaryHeap;
 
 use roaring::RoaringBitmap;
 
 use tachyon_core::{CollectionSchema, DocId, FieldId, Value};
-use tachyon_index::{FieldPostings, FuzzyMatcher, IndexSource};
+use tachyon_index::{FuzzyMatcher, IndexSource};
 
-use crate::bm25::{self, FieldStats};
+use crate::bm25::FieldStats;
 use crate::filter;
-use crate::query_text::{self, ParsedQuery};
+use crate::query_text;
 use crate::request::{MatchMode, SearchRequest};
-use crate::score::{self, ScoreComponents, ScoreWeights};
+use crate::score::ScoreComponents;
 use crate::sort::{self, SortClause, SortKey, SortValue};
+use crate::wand;
 
 /// Cap on how many dictionary terms one query token may expand into. Without
 /// it, a one-character prefix on a large collection would walk the entire term
 /// dictionary.
 pub const MAX_TERM_EXPANSIONS: usize = 128;
-
-/// Sentinel in the edits array meaning "this token did not match here".
-const UNMATCHED: u32 = u32::MAX;
-
-/// Hasher for the document accumulator's index.
-///
-/// The standard library's default is SipHash, which is the right choice for a
-/// map whose keys an attacker chooses — and the wrong one here. These keys are
-/// internal doc ids we assigned ourselves, sequential and dense, and a broad
-/// query hashes one per match.
-#[derive(Default, Clone, Copy)]
-struct DocIdHasher(u64);
-
-impl std::hash::Hasher for DocIdHasher {
-    fn finish(&self) -> u64 {
-        self.0
-    }
-
-    fn write(&mut self, bytes: &[u8]) {
-        // Only ever called with a doc id, but stay correct if that changes.
-        for byte in bytes {
-            self.write_u64(*byte as u64);
-        }
-    }
-
-    fn write_u32(&mut self, value: u32) {
-        self.write_u64(value as u64);
-    }
-
-    fn write_u64(&mut self, value: u64) {
-        // Fibonacci hashing: multiply by 2^64 / φ and fold the high bits, which
-        // mix in every input bit, down to where the map reads them.
-        self.0 = (self.0 ^ value).wrapping_mul(0x9E37_79B9_7F4A_7C15);
-        self.0 ^= self.0 >> 32;
-    }
-}
-
-type DocIdBuildHasher = std::hash::BuildHasherDefault<DocIdHasher>;
 
 /// Everything a search reads.
 pub struct SearchContext<'a> {
@@ -107,7 +73,7 @@ impl<'a> SearchContext<'a> {
     /// Corpus statistics for a field, summed across every source. BM25 needs
     /// global numbers; per-source stats would score the same document
     /// differently depending on which segment it landed in.
-    fn field_stats(&self, field: FieldId) -> FieldStats {
+    pub(crate) fn field_stats(&self, field: FieldId) -> FieldStats {
         let mut doc_count = 0u32;
         let mut total_len = 0u64;
         for source in &self.sources {
@@ -117,10 +83,40 @@ impl<'a> SearchContext<'a> {
         FieldStats::new(doc_count, total_len)
     }
 
-    fn value(&self, doc_id: DocId, field: FieldId) -> Option<Cow<'a, Value>> {
+    /// A document's declared *range* (`min_doc_id()..end_doc_id()`) can be
+    /// claimed by more than one source at once: a memtable that reserved a
+    /// range a later merge went on to claim (see `MemTable::reserve`) still
+    /// reports that span as its own, even though nothing is ever live there.
+    /// So a range match alone never stops the search below — every method
+    /// here tries each range-matching source in turn and falls through
+    /// whenever one turns out not to actually hold `doc_id` live, rather
+    /// than trusting the first (possibly hole-only) match.
+    pub(crate) fn value(&self, doc_id: DocId, field: FieldId) -> Option<Cow<'a, Value>> {
         self.sources.iter().find_map(|s| {
             (doc_id >= s.min_doc_id() && doc_id < s.end_doc_id()).then(|| s.value(doc_id, field))?
         })
+    }
+
+    /// The owning source's own `field_len`, or `0` if no source actually
+    /// holds this doc id live. See `Self::value`'s doc comment for why a
+    /// range match alone isn't enough to stop the search.
+    pub(crate) fn field_len(&self, doc_id: DocId, field: FieldId) -> u32 {
+        self.sources
+            .iter()
+            .find(|s| doc_id >= s.min_doc_id() && doc_id < s.end_doc_id() && s.is_live(doc_id))
+            .map_or(0, |s| s.field_len(doc_id, field))
+    }
+
+    /// Whether `doc_id` is live in whichever source actually holds it, and
+    /// not collection-wide tombstoned. Centralizes the liveness/tombstone
+    /// check the old per-posting walk repeated once per source per token;
+    /// here it runs once per document actually reached by a driver. See
+    /// `Self::value`'s doc comment for why a range match alone isn't enough.
+    pub(crate) fn is_live(&self, doc_id: DocId) -> bool {
+        self.sources
+            .iter()
+            .any(|s| doc_id >= s.min_doc_id() && doc_id < s.end_doc_id() && s.is_live(doc_id))
+            && !self.deleted.contains(doc_id)
     }
 }
 
@@ -144,133 +140,26 @@ pub struct ScoredDoc {
 #[derive(Debug, Clone)]
 pub struct SearchOutcome {
     /// Total matching documents, not just the returned page (PRD §13 `found`).
+    /// A lower bound, not necessarily exact, whenever `found_is_exact` is
+    /// `false`.
     pub found: usize,
     pub hits: Vec<ScoredDoc>,
     /// Every document that matched, for faceting over the full result set
     /// rather than the page (PRD §7.7: "accurate counts after filters").
+    /// Same approximation caveat as `found` — facets read this bitmap
+    /// directly, so they inherit it automatically.
     pub matched: RoaringBitmap,
-}
-
-/// Per-(document, field, token) evidence, in flat arrays.
-///
-/// `slot` identifies a matched document; `field` is an index into the
-/// request's `query_by` list, not a schema field id.
-struct Accumulator {
-    num_fields: usize,
-    num_tokens: usize,
-    /// Doc id to slot.
-    index: std::collections::HashMap<DocId, u32, DocIdBuildHasher>,
-    /// Slot to doc id.
-    docs: Vec<DocId>,
-    /// Best BM25 contribution, addressed by [`Accumulator::cell`].
-    scores: Vec<f32>,
-    /// Cheapest edit distance, same addressing. [`UNMATCHED`] if absent.
-    edits: Vec<u32>,
-    /// Token positions, same addressing. Empty unless positions are needed.
-    positions: Vec<Vec<u32>>,
-    needs_positions: bool,
-}
-
-impl Accumulator {
-    fn new(num_fields: usize, num_tokens: usize, needs_positions: bool) -> Accumulator {
-        Accumulator {
-            num_fields: num_fields.max(1),
-            num_tokens: num_tokens.max(1),
-            index: std::collections::HashMap::default(),
-            docs: Vec::new(),
-            scores: Vec::new(),
-            edits: Vec::new(),
-            positions: Vec::new(),
-            needs_positions,
-        }
-    }
-
-    /// Slot for a document, appending a fresh block the first time it is seen.
-    ///
-    /// One hash lookup, not the two a `get` followed by an `insert` would cost:
-    /// this runs once per posting on a broad query, which is the single most
-    /// executed line in a search.
-    fn slot(&mut self, doc_id: DocId) -> usize {
-        let next = self.docs.len() as u32;
-        match self.index.entry(doc_id) {
-            std::collections::hash_map::Entry::Occupied(existing) => *existing.get() as usize,
-            std::collections::hash_map::Entry::Vacant(empty) => {
-                empty.insert(next);
-                self.docs.push(doc_id);
-
-                let block = self.num_fields * self.num_tokens;
-                self.scores.resize(self.scores.len() + block, 0.0);
-                self.edits.resize(self.edits.len() + block, UNMATCHED);
-                if self.needs_positions {
-                    self.positions.resize(self.positions.len() + block, Vec::new());
-                }
-                next as usize
-            }
-        }
-    }
-
-    /// Put every position list into the sorted, deduplicated form the phrase
-    /// and proximity checks need.
-    ///
-    /// Done once, after the walk, rather than on each read: a position list is
-    /// read once per field per phrase token and again for proximity, and
-    /// sorting a fresh clone every time was the largest cost in scoring a
-    /// multi-token query. Positions arrive out of order because one token can
-    /// expand into several terms, each contributing its own occurrences.
-    fn normalize_positions(&mut self) {
-        for list in &mut self.positions {
-            if list.len() > 1 {
-                list.sort_unstable();
-                list.dedup();
-            }
-        }
-    }
-
-    fn cell(&self, slot: usize, field: usize, token: usize) -> usize {
-        (slot * self.num_fields + field) * self.num_tokens + token
-    }
-
-    /// Whether the token matched in this field of this document.
-    fn matched(&self, slot: usize, field: usize, token: usize) -> bool {
-        self.edits[self.cell(slot, field, token)] != UNMATCHED
-    }
-
-    /// BM25 for one field of one document: the sum over its matched tokens.
-    fn field_bm25(&self, slot: usize, field: usize) -> f32 {
-        let start = self.cell(slot, field, 0);
-        self.scores[start..start + self.num_tokens].iter().sum()
-    }
-
-    fn field_edits(&self, slot: usize, field: usize) -> u32 {
-        let start = self.cell(slot, field, 0);
-        self.edits[start..start + self.num_tokens].iter().filter(|e| **e != UNMATCHED).sum()
-    }
-
-    fn field_matched_tokens(&self, slot: usize, field: usize) -> usize {
-        let start = self.cell(slot, field, 0);
-        self.edits[start..start + self.num_tokens].iter().filter(|e| **e != UNMATCHED).count()
-    }
-
-    /// Sorted, deduplicated positions of one token in one field.
-    ///
-    /// Valid only after [`Accumulator::normalize_positions`]; borrowed rather
-    /// than cloned, so reading a position list costs nothing.
-    fn token_positions(&self, slot: usize, field: usize, token: usize) -> &[u32] {
-        if !self.needs_positions {
-            return &[];
-        }
-        &self.positions[self.cell(slot, field, token)]
-    }
-
-    fn len(&self) -> usize {
-        self.docs.len()
-    }
+    /// `false` iff pruning skipped at least one block of at least one
+    /// term's postings while answering this query. See `wand.rs`'s module
+    /// doc for exactly which mechanism this tracks (only the block-level
+    /// one; the older scoped mechanism never causes approximation).
+    pub found_is_exact: bool,
 }
 
 /// Run a search.
 ///
-/// Filters are evaluated first, into a bitmap, so the postings walk can reject
-/// a document before scoring it rather than after.
+/// Filters are evaluated first, into a bitmap, so the pruning walk can
+/// reject a document before ever resolving it.
 pub fn execute(ctx: &SearchContext, req: &SearchRequest) -> SearchOutcome {
     let filter_set = req.filter_expr.as_ref().map(|expr| filter::evaluate(expr, &ctx.sources));
     let filter = filter_set.as_ref();
@@ -298,211 +187,119 @@ pub fn execute(ctx: &SearchContext, req: &SearchRequest) -> SearchOutcome {
 
     // Positions are read only by proximity scoring and phrase verification. A
     // single-token query needs neither — the proximity of one term is 1.0 by
-    // definition — and collecting them anyway is the largest avoidable cost on
+    // definition — and decoding them anyway is the largest avoidable cost on
     // a query that matches a lot of documents.
     let needs_positions = tokens.len() > 1 || !query.phrases.is_empty();
-    let mut acc = Accumulator::new(req.query_by.len(), tokens.len(), needs_positions);
-
-    // Reused across candidates so the outer `Vec` does not reallocate per
-    // candidate. The `Cow` each slot holds is a zero-cost borrow for a
-    // memtable source but a fresh decode for a segment one — resolving a
-    // term against every source once, rather than once for `doc_freq` and
-    // again for the postings walk, still matters for a segment exactly
-    // because that decode is real work now.
-    let mut per_source: Vec<Option<Cow<'_, FieldPostings>>> = Vec::with_capacity(ctx.sources.len());
-
-    for (field_pos, &(field, _boost)) in req.query_by.iter().enumerate() {
-        let stats = ctx.field_stats(field);
-        if stats.doc_count == 0 {
-            continue;
-        }
-
-        for (token_idx, candidates) in expansions.iter().enumerate() {
-            for candidate in candidates {
-                // Resolve the term in each source once. Asking for the document
-                // frequency and then for the postings would walk every source's
-                // term dictionary twice for the same term.
-                per_source.clear();
-                per_source.extend(ctx.sources.iter().map(|s| s.postings(&candidate.term, field)));
-
-                let doc_freq: u32 =
-                    per_source.iter().map(|p| p.as_ref().map_or(0, |p| p.doc_freq())).sum();
-                if doc_freq == 0 {
-                    continue;
-                }
-                let idf = bm25::idf(doc_freq, stats.doc_count);
-
-                for (source, postings) in ctx.sources.iter().zip(per_source.iter()) {
-                    let Some(postings) = postings else {
-                        continue;
-                    };
-                    for posting in &postings.docs {
-                        let doc_id = posting.doc_id;
-                        if !source.is_live(doc_id) || ctx.deleted.contains(doc_id) {
-                            continue;
-                        }
-                        if filter.is_some_and(|f| !f.contains(doc_id)) {
-                            continue;
-                        }
-
-                        let field_len = source.field_len(doc_id, field);
-                        let contribution = bm25::term_score(posting.tf(), field_len, stats, idf);
-
-                        let slot = acc.slot(doc_id);
-                        let cell = acc.cell(slot, field_pos, token_idx);
-
-                        // A token expanded into several terms keeps its best
-                        // single contribution rather than the sum, so matching
-                        // many prefix variants is not itself a relevance signal.
-                        if contribution > acc.scores[cell] {
-                            acc.scores[cell] = contribution;
-                        }
-                        if candidate.edits < acc.edits[cell] {
-                            acc.edits[cell] = candidate.edits;
-                        }
-                        if needs_positions {
-                            acc.positions[cell].extend_from_slice(&posting.positions);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    acc.normalize_positions();
-    finish(ctx, req, &query, acc)
-}
-
-/// Turn the accumulator into a ranked page.
-fn finish(
-    ctx: &SearchContext,
-    req: &SearchRequest,
-    query: &ParsedQuery,
-    acc: Accumulator,
-) -> SearchOutcome {
-    let tokens = &query.tokens;
-    let weights = ScoreWeights::default();
-    let max_boost = score::max_boost(ctx.schema);
     let allowed_edits = total_allowed_edits(ctx.schema, tokens, req);
-    let popularity_field = ctx.schema.field(score::POPULARITY_FIELD).map(|(id, _)| id);
 
-    let required = match req.match_mode {
-        MatchMode::All => tokens.len(),
-        MatchMode::Any => 1,
+    // Same eligibility rule the scoped mechanism has always used: only sound
+    // when relevance score decides the *primary* order. A field-only sort
+    // could still need a low-relevance document, so pruning is skipped
+    // entirely and both drivers degrade to a plain, exact merge/leapfrog —
+    // see `wand.rs` §7.3 in the design notes for why this falls out of the
+    // algorithm itself rather than needing a separate code path.
+    let prunable = req
+        .sort_clauses
+        .as_ref()
+        .is_none_or(|clauses| clauses.first().is_some_and(|c| c.key == SortKey::TextMatch));
+
+    let mut frontiers = wand::build_frontiers(ctx, req, &expansions);
+    let scorer = wand::DocScorer::new(ctx, req, filter, allowed_edits, needs_positions, tokens.len());
+    let mut top_k = prunable.then(|| TopKByScore::new(req.window()));
+    let mut candidates: Vec<Ranked> = Vec::new(); // used only when `top_k` is None
+
+    let (matched_ids, any_skip) = match req.match_mode {
+        MatchMode::Any => {
+            wand::run_disjunctive(&mut frontiers, &query, &scorer, &mut top_k, &mut candidates)
+        }
+        MatchMode::All => {
+            wand::run_conjunctive(&mut frontiers, &query, &scorer, &mut top_k, &mut candidates)
+        }
     };
 
-    let num_fields = req.query_by.len();
-    let mut candidates: Vec<Ranked> = Vec::new();
-    // Gathered flat and turned into a bitmap at the end. Documents are visited
-    // in postings-walk order, which is not doc id order, and inserting an
-    // unordered run into a roaring bitmap shifts elements inside its container
-    // on nearly every call — a real cost when a broad query matches thousands
-    // of documents, and this set is built on every search that facets.
-    let mut matched_ids: Vec<DocId> = Vec::new();
-    // Reused across documents so scoring allocates once, not once per hit.
-    let mut present: Vec<&[u32]> = Vec::with_capacity(tokens.len());
-
-    for slot in 0..acc.len() {
-        let doc_id = acc.docs[slot];
-
-        // A document qualifies on the union of its fields: "wireless" in the
-        // title and "mouse" in the description is still a match for
-        // "wireless mouse".
-        let union = (0..tokens.len())
-            .filter(|token| (0..num_fields).any(|f| acc.matched(slot, f, *token)))
-            .count();
-        if union < required {
-            continue;
-        }
-
-        // A phrase is all-or-nothing regardless of match mode: quoting terms
-        // is an explicit request for them to be adjacent.
-        if !query.phrases.is_empty() && !satisfies_phrases(&acc, slot, req, &query.phrases) {
-            continue;
-        }
-
-        matched_ids.push(doc_id);
-
-        // Pick the field that best explains this match.
-        let mut best_field = 0usize;
-        let mut best_bm25 = 0.0f32;
-        let mut best_boosted = f32::NEG_INFINITY;
-        for field_pos in 0..num_fields {
-            let raw = acc.field_bm25(slot, field_pos);
-            let boosted = raw * req.query_by[field_pos].1;
-            if boosted > best_boosted {
-                best_boosted = boosted;
-                best_bm25 = raw;
-                best_field = field_pos;
-            }
-        }
-
-        // Proximity is only meaningful over the tokens this field actually has.
-        present.clear();
-        present.extend(
-            (0..tokens.len())
-                .filter(|token| acc.matched(slot, best_field, *token))
-                .map(|token| acc.token_positions(slot, best_field, token)),
-        );
-
-        let matched_here = acc.field_matched_tokens(slot, best_field);
-        let proximity = if matched_here == tokens.len() {
-            score::proximity(&present)
-        } else {
-            // A partial match in this field cannot claim tight proximity.
-            score::proximity(&present) * matched_here as f32 / tokens.len() as f32
-        };
-
-        let popularity = popularity_field
-            .and_then(|f| ctx.value(doc_id, f))
-            .and_then(|v| v.as_f64())
-            .map(|v| score::normalize_popularity(v as f32))
-            .unwrap_or(0.0);
-
-        let components = ScoreComponents {
-            bm25: score::normalize_bm25(best_bm25),
-            field_boost: score::normalize_field_boost(req.query_by[best_field].1, max_boost),
-            proximity,
-            typo_penalty: score::typo_penalty(acc.field_edits(slot, best_field), allowed_edits),
-            popularity,
-        };
-
-        let score = components.combine(&weights);
-        candidates.push(Ranked {
-            doc_id,
-            score,
-            components,
-            sort_values: sort_values(ctx, req, doc_id, score),
-        });
-    }
-
-    // A document reaches this point at most once, so the count is exact and no
-    // deduplication is needed.
+    // Both drivers visit doc ids in strictly ascending order (`MergeCursor`
+    // merges across sources in doc-id order, and a driver only ever visits
+    // a doc id once), so this is a direct build, not a sort-then-dedup.
     let found = matched_ids.len();
-    let matched = sorted_bitmap(matched_ids);
+    let matched = RoaringBitmap::from_sorted_iter(matched_ids)
+        .expect("both drivers visit docs in ascending order");
 
+    let candidates = top_k.map_or(candidates, TopKByScore::into_vec);
     let hits = paginate(req, candidates);
-    SearchOutcome { found, hits, matched }
+    SearchOutcome { found, hits, matched, found_is_exact: !any_skip }
 }
 
-/// Build a bitmap from doc ids in arbitrary order, sorting first so the fill
-/// is linear rather than an insert-and-shift per element.
-///
-/// Worth it because a result set is sparse: roaring holds it in array
-/// containers, where an out-of-order insert shifts the tail of the container.
-/// The same trick loses on a dense set — see `collect_docs` in the index
-/// crate's columns, which deliberately does not sort.
-fn sorted_bitmap(mut doc_ids: Vec<DocId>) -> RoaringBitmap {
-    if doc_ids.is_empty() {
-        return RoaringBitmap::new();
+/// Bounds how many fully-scored candidates `finish` carries forward, so a
+/// broad query does not carry every match through proximity/popularity
+/// scoring only to discard most of them in `paginate`. A max-heap ordered so
+/// `peek`/`pop` return the *worst* of the currently-kept set — the one
+/// candidate for eviction, and the threshold a new candidate's bound must
+/// clear to be worth fully scoring.
+pub(crate) struct TopKByScore {
+    window: usize,
+    heap: BinaryHeap<ScoredEntry>,
+}
+
+struct ScoredEntry(Ranked);
+
+impl PartialEq for ScoredEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.score == other.0.score && self.0.doc_id == other.0.doc_id
     }
-    doc_ids.sort_unstable();
-    doc_ids.dedup();
-    RoaringBitmap::from_sorted_iter(doc_ids).expect("doc ids were sorted and deduplicated")
+}
+impl Eq for ScoredEntry {}
+impl PartialOrd for ScoredEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for ScoredEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Reversed against the real ranking (lower score / higher doc id
+        // first): a `BinaryHeap` is a max-heap, and `peek`/`pop` should
+        // surface the *worst* kept candidate, not the best.
+        other.0.score.total_cmp(&self.0.score).then(other.0.doc_id.cmp(&self.0.doc_id))
+    }
+}
+
+impl TopKByScore {
+    pub(crate) fn new(window: usize) -> TopKByScore {
+        TopKByScore { window, heap: BinaryHeap::with_capacity(window.min(1024)) }
+    }
+
+    /// The score a new candidate's bound must meet or beat to be worth fully
+    /// scoring. `None` while there's still room in the kept set — nothing to
+    /// prune against yet.
+    pub(crate) fn threshold(&self) -> Option<f32> {
+        if self.heap.len() < self.window {
+            None
+        } else {
+            self.heap.peek().map(|worst| worst.0.score)
+        }
+    }
+
+    pub(crate) fn push(&mut self, ranked: Ranked) {
+        if self.heap.len() < self.window {
+            self.heap.push(ScoredEntry(ranked));
+            return;
+        }
+        let Some(worst) = self.heap.peek() else { return };
+        let replaces =
+            ranked.score > worst.0.score || (ranked.score == worst.0.score && ranked.doc_id < worst.0.doc_id);
+        if replaces {
+            self.heap.pop();
+            self.heap.push(ScoredEntry(ranked));
+        }
+    }
+
+    pub(crate) fn into_vec(self) -> Vec<Ranked> {
+        self.heap.into_iter().map(|entry| entry.0).collect()
+    }
 }
 
 /// An empty query matches every live document, so filters and sorting can be
-/// used on their own to browse a collection.
+/// used on their own to browse a collection. No relevance signal to bound
+/// here — score is hardcoded `0.0` — so this never approximates.
 fn match_all(
     ctx: &SearchContext,
     req: &SearchRequest,
@@ -531,12 +328,12 @@ fn match_all(
 
     let found = matched.len() as usize;
     let hits = paginate(req, candidates);
-    SearchOutcome { found, hits, matched }
+    SearchOutcome { found, hits, matched, found_is_exact: true }
 }
 
 /// Values for each sort clause, in clause order. Empty when the request does
 /// not sort, in which case ranking falls back to score.
-fn sort_values(
+pub(crate) fn sort_values(
     ctx: &SearchContext,
     req: &SearchRequest,
     doc_id: DocId,
@@ -590,40 +387,6 @@ fn paginate(req: &SearchRequest, mut candidates: Vec<Ranked>) -> Vec<ScoredDoc> 
         .take(req.limit)
         .map(|r| ScoredDoc { doc_id: r.doc_id, score: r.score, components: r.components })
         .collect()
-}
-
-/// Whether some single field places every phrase's tokens consecutively.
-///
-/// A phrase must be satisfied within one field — `title` ending in "mouse" and
-/// `description` starting with "pad" is not the phrase "mouse pad".
-fn satisfies_phrases(
-    acc: &Accumulator,
-    slot: usize,
-    req: &SearchRequest,
-    phrases: &[(usize, usize)],
-) -> bool {
-    phrases.iter().all(|&(start, end)| {
-        (0..req.query_by.len()).any(|field| phrase_in_field(acc, slot, field, start, end))
-    })
-}
-
-fn phrase_in_field(acc: &Accumulator, slot: usize, field: usize, start: usize, end: usize) -> bool {
-    // Every token of the phrase has to be present in this field at all.
-    if (start..=end).any(|token| !acc.matched(slot, field, token)) {
-        return false;
-    }
-
-    // Walk the first token's positions; each is a candidate phrase start.
-    let first = acc.token_positions(slot, field, start);
-
-    first.iter().any(|&anchor| {
-        (start + 1..=end).enumerate().all(|(offset, token)| {
-            let positions = acc.token_positions(slot, field, token);
-            anchor
-                .checked_add(offset as u32 + 1)
-                .is_some_and(|expected| positions.binary_search(&expected).is_ok())
-        })
-    })
 }
 
 /// Total edit budget the typo table grants this query, used to normalize the
@@ -708,12 +471,12 @@ fn expand_token(
 
 /// A candidate document with everything needed to order it.
 #[derive(Debug, Clone)]
-struct Ranked {
-    doc_id: DocId,
-    score: f32,
-    components: ScoreComponents,
+pub(crate) struct Ranked {
+    pub(crate) doc_id: DocId,
+    pub(crate) score: f32,
+    pub(crate) components: ScoreComponents,
     /// One entry per sort clause; empty when ranking by relevance.
-    sort_values: Vec<SortValue>,
+    pub(crate) sort_values: Vec<SortValue>,
 }
 
 #[cfg(test)]
@@ -732,6 +495,11 @@ mod tests {
                 FieldSchema::new("title", FieldType::Text),
                 FieldSchema::new("description", FieldType::Text),
                 FieldSchema::new("popularity", FieldType::Int).with_sort(true),
+                // A second sortable field, independent of relevance — unlike
+                // `popularity`, which is also a scoring signal (`combine()`'s
+                // 5% component), so it can't double as a tie-break that's
+                // independent of the thing it's supposedly tying on.
+                FieldSchema::new("price", FieldType::Int).with_sort(true),
             ],
         )
     }
@@ -1301,5 +1069,621 @@ mod tests {
         let out =
             f.search(SearchParams { query_by: Some("description".into()), ..query("comfortable") });
         assert_eq!(f.ids(&out), vec!["1"]);
+    }
+
+    // --- score-bound pruning (scoped block-max WAND) -----------------------
+
+    /// Every document matches "mouse", with relevance varying by how many
+    /// times it repeats in the title — enough documents, with enough score
+    /// variation, that a small `limit` genuinely exercises pruning rather
+    /// than the top-k set just happening to equal every match.
+    fn broad_corpus(n: usize) -> Fixture {
+        let docs: Vec<serde_json::Value> = (0..n)
+            .map(|i| {
+                let repeats = (i % 5) + 1;
+                let title = vec!["mouse"; repeats].join(" ");
+                json!({
+                    "id": i.to_string(),
+                    "title": title,
+                    "description": "a mouse for the desk",
+                    "popularity": (i * 37 % 1000) as i64,
+                })
+            })
+            .collect();
+        Fixture::new(&docs)
+    }
+
+    #[test]
+    fn pruning_returns_the_identical_top_k_as_exhaustive_scoring() {
+        let f = broad_corpus(40);
+        let small = f.search(SearchParams { limit: Some(5), ..query("mouse") });
+        let large = f.search(SearchParams { limit: Some(40), ..query("mouse") });
+
+        assert_eq!(small.found, 40);
+        assert_eq!(small.found, large.found);
+
+        let small_ids: Vec<DocId> = small.hits.iter().map(|h| h.doc_id).collect();
+        let large_first_5: Vec<DocId> = large.hits.iter().take(5).map(|h| h.doc_id).collect();
+        assert_eq!(small_ids, large_first_5, "pruning must not change which docs win the page");
+
+        let small_scores: Vec<f32> = small.hits.iter().map(|h| h.score).collect();
+        let large_scores: Vec<f32> = large.hits.iter().take(5).map(|h| h.score).collect();
+        assert_eq!(small_scores, large_scores, "and not their exact scores either");
+    }
+
+    #[test]
+    fn pruning_does_not_change_the_matched_set() {
+        // facets::compute reads this bitmap directly — it must be identical
+        // regardless of how aggressively scoring was pruned to build the page.
+        let f = broad_corpus(40);
+        let small = f.search(SearchParams { limit: Some(5), ..query("mouse") });
+        let large = f.search(SearchParams { limit: Some(40), ..query("mouse") });
+        assert_eq!(small.matched, large.matched);
+    }
+
+    #[test]
+    fn pruning_is_bypassed_for_a_field_only_sort() {
+        // "winner" barely matches (weak relevance) but has the lowest
+        // popularity; every filler has much stronger relevance. Under
+        // sort=popularity:asc, "winner" must still win — which is only true
+        // if a field-only sort disables score-bound pruning entirely.
+        let mut docs = vec![json!({
+            "id": "winner", "title": "desk accessory", "description": "a mouse pad, barely",
+            "popularity": 0,
+        })];
+        for i in 0..30 {
+            docs.push(json!({
+                "id": format!("filler{i}"),
+                "title": "mouse mouse mouse mouse mouse",
+                "description": "mouse mouse mouse",
+                "popularity": 100 + i,
+            }));
+        }
+        let f = Fixture::new(&docs);
+        let out = f.search(SearchParams {
+            sort: Some("popularity:asc".into()),
+            limit: Some(3),
+            match_mode: Some("any".into()),
+            ..query("mouse")
+        });
+        assert_eq!(
+            f.ids(&out)[0],
+            "winner",
+            "the lowest-popularity doc must win regardless of its weak relevance"
+        );
+    }
+
+    #[test]
+    fn pruning_stays_sound_with_a_secondary_sort_clause() {
+        // Two documents tie exactly on relevance — identical title *and*
+        // popularity, since popularity is itself part of combine()'s score,
+        // not just a sort key — differing only in `price`.
+        // sort=_text_match:desc,price:asc must still order them correctly,
+        // and both must survive pruning to even be compared, proving a
+        // TextMatch-primary sort keeps pruning valid.
+        //
+        // Popularity is held constant across the whole corpus so it can't
+        // confound relevance, and a block of non-matching documents keeps
+        // "mouse"'s document frequency well under the corpus size — with
+        // *every* document matching, idf collapses toward zero and the tiny
+        // 5%-weighted popularity term would dominate instead of BM25,
+        // which is the opposite of what this test needs to isolate.
+        let mut docs = vec![
+            json!({"id": "tie_high_price", "title": "mouse mouse mouse", "description": "d", "popularity": 50, "price": 500}),
+            json!({"id": "tie_low_price", "title": "mouse mouse mouse", "description": "d", "popularity": 50, "price": 10}),
+        ];
+        for i in 0..30 {
+            docs.push(json!({
+                "id": format!("filler{i}"),
+                "title": "mouse", "description": "d",
+                "popularity": 50,
+                "price": (i * 7 % 1000) as i64,
+            }));
+        }
+        for i in 0..50 {
+            docs.push(json!({
+                "id": format!("noise{i}"),
+                "title": "keyboard", "description": "d",
+                "popularity": 50,
+                "price": (i * 11 % 1000) as i64,
+            }));
+        }
+        let f = Fixture::new(&docs);
+        let out = f.search(SearchParams {
+            sort: Some("_text_match:desc,price:asc".into()),
+            limit: Some(3),
+            match_mode: Some("any".into()),
+            ..query("mouse")
+        });
+        let ids = f.ids(&out);
+        assert_eq!(
+            ids,
+            vec!["tie_low_price", "tie_high_price", "filler0"],
+            "the tf=3 docs must clearly outrank every tf=1 filler, then order by price on their tie"
+        );
+    }
+
+    #[test]
+    fn pruning_is_correct_beyond_the_first_page() {
+        let f = broad_corpus(40);
+        let page1 = f.search(SearchParams { limit: Some(5), offset: Some(0), ..query("mouse") });
+        let page2 = f.search(SearchParams { limit: Some(5), offset: Some(5), ..query("mouse") });
+        let exhaustive = f.search(SearchParams { limit: Some(40), ..query("mouse") });
+
+        let combined: Vec<DocId> =
+            page1.hits.iter().chain(page2.hits.iter()).map(|h| h.doc_id).collect();
+        let expected: Vec<DocId> = exhaustive.hits.iter().take(10).map(|h| h.doc_id).collect();
+        assert_eq!(combined, expected, "window = offset + limit must size the kept set correctly");
+    }
+
+    #[test]
+    fn limit_zero_still_reports_found_and_matched_without_scoring() {
+        let f = broad_corpus(10);
+        let out = f.search(SearchParams { limit: Some(0), ..query("mouse") });
+        assert!(out.hits.is_empty());
+        assert_eq!(out.found, 10);
+        assert_eq!(out.matched.len(), 10);
+    }
+
+    // --- true block-max WAND (wand.rs) --------------------------------------
+
+    /// A corpus flushed to a real on-disk segment, for tests that need
+    /// genuine block structure (`POSTING_BLOCK_SIZE = 128` postings per
+    /// block) — a memtable alone has none, so a test that must exercise
+    /// `SegmentPostingCursor`'s block-jump path needs a real segment.
+    struct SegmentFixture {
+        _dir: tempfile::TempDir,
+        schema: CollectionSchema,
+        reader: tachyon_index::SegmentReader,
+    }
+
+    impl SegmentFixture {
+        fn new(docs: &[serde_json::Value]) -> SegmentFixture {
+            let schema = schema();
+            let mut m = MemTable::new(0, &schema);
+            for doc in docs {
+                m.insert(ParsedDocument::parse(doc.clone(), &schema).unwrap());
+            }
+            let dir = tempfile::tempdir().unwrap();
+            let encoded = tachyon_index::encode(&m, &schema).unwrap();
+            let paths = tachyon_index::SegmentFilePaths {
+                terms: dir.path().join("seg.terms"),
+                ids: dir.path().join("seg.ids"),
+                post: dir.path().join("seg.post"),
+                col: dir.path().join("seg.col"),
+                doc: dir.path().join("seg.doc"),
+            };
+            std::fs::write(&paths.terms, &encoded.terms).unwrap();
+            std::fs::write(&paths.ids, &encoded.ids).unwrap();
+            std::fs::write(&paths.post, &encoded.post).unwrap();
+            std::fs::write(&paths.col, &encoded.col).unwrap();
+            std::fs::write(&paths.doc, &encoded.doc).unwrap();
+            let reader = tachyon_index::SegmentReader::open(&paths, &schema).unwrap();
+            SegmentFixture { _dir: dir, schema, reader }
+        }
+
+        fn search(&self, params: SearchParams) -> SearchOutcome {
+            let req = SearchRequest::resolve(params, &self.schema).unwrap();
+            let deleted = RoaringBitmap::new();
+            let ctx = SearchContext::new(&self.schema, vec![&self.reader], &deleted);
+            execute(&ctx, &req)
+        }
+    }
+
+    /// A corpus engineered so a *block*-level bound can be proven, not just
+    /// hoped, to fall below an already-full top-K's threshold:
+    ///
+    /// - `block0_count` "kept" documents come first (the lowest doc ids, so
+    ///   they occupy the term's first posting block): term frequency
+    ///   `high_tf` and a high `popularity`. `popularity` matters because
+    ///   `bound_to_combined_score` always assumes the *best possible*
+    ///   popularity (1.0) — giving the real kept documents a genuinely high
+    ///   one too keeps that assumption from being free, unearned slack for
+    ///   every other block's bound to hide behind. BM25's own saturation
+    ///   (`K1 = 1.2`) caps how much a *single* token's real score can ever
+    ///   exceed a `tf = 1` bound (≈1.3x, however extreme `high_tf` gets, or
+    ///   however favorable the length normalization) — nowhere near enough
+    ///   on its own to clear a threshold that also credits a full
+    ///   popularity component.
+    /// - `filler_docs` documents that do NOT contain "mouse" at all, so
+    ///   "mouse"'s idf stays well above zero — an every-document-matches
+    ///   query collapses idf toward zero and makes any bound comparison
+    ///   meaningless (the same trap `pruning_stays_sound_with_a_secondary_
+    ///   sort_clause` above avoids). Long enough (20 tokens) to keep the
+    ///   corpus's average field length from being dominated by the tiny
+    ///   `tf = 1` tail, which is what keeps the *kept* documents' own
+    ///   length normalization close to its floor.
+    /// - `block1_count` "tail" documents, at the lowest possible term
+    ///   frequency (1) and no popularity, forming the term's second (and
+    ///   later) posting blocks.
+    fn skewed_block_corpus(
+        filler_docs: usize,
+        block0_count: usize,
+        high_tf: usize,
+        block1_count: usize,
+    ) -> Vec<serde_json::Value> {
+        let mut docs = Vec::new();
+        for i in 0..block0_count {
+            let title = vec!["mouse"; high_tf].join(" ");
+            docs.push(json!({"id": format!("k{i}"), "title": title, "description": "d", "popularity": 3000}));
+        }
+        for i in 0..filler_docs {
+            let title = (0..20).map(|w| format!("filler{w}")).collect::<Vec<_>>().join(" ");
+            docs.push(json!({"id": format!("f{i}"), "title": title, "description": "d"}));
+        }
+        for i in 0..block1_count {
+            docs.push(json!({"id": format!("t{i}"), "title": "mouse", "description": "d"}));
+        }
+        docs
+    }
+
+    /// Same cliff shape as [`skewed_block_corpus`], but with two tokens that
+    /// always co-occur at the same term frequency — for a two-token `All`
+    /// mode query whose intersection is the whole corpus, so a genuine
+    /// undercount can only come from the driver's own pruning, never from
+    /// the intersection legitimately excluding anything.
+    fn skewed_block_corpus_two_tokens(
+        filler_docs: usize,
+        block0_count: usize,
+        high_tf: usize,
+        block1_count: usize,
+    ) -> Vec<serde_json::Value> {
+        let mut docs = Vec::new();
+        for i in 0..block0_count {
+            let title = vec!["mouse pad"; high_tf].join(" ");
+            docs.push(json!({"id": format!("k{i}"), "title": title, "description": "d", "popularity": 3000}));
+        }
+        for i in 0..filler_docs {
+            let title = (0..20).map(|w| format!("filler{w}")).collect::<Vec<_>>().join(" ");
+            docs.push(json!({"id": format!("f{i}"), "title": title, "description": "d"}));
+        }
+        for i in 0..block1_count {
+            docs.push(json!({"id": format!("t{i}"), "title": "mouse pad", "description": "d"}));
+        }
+        docs
+    }
+
+    #[test]
+    fn soundness_under_a_full_window_in_both_match_modes() {
+        // A corpus spanning several blocks — a stronger soundness check than
+        // the single-block `pruning_returns_the_identical_top_k...` above —
+        // with `limit` == every match, so pruning never engages in either
+        // driver and `found_is_exact` must come back `true` for both modes.
+        let docs = skewed_block_corpus(1000, 128, 20, 122);
+        let f = SegmentFixture::new(&docs);
+
+        for mode in ["any", "all"] {
+            let out = f.search(SearchParams {
+                q: Some("mouse".into()),
+                prefix: Some(false),
+                query_by: Some("title".into()),
+                match_mode: Some(mode.into()),
+                limit: Some(250),
+                ..Default::default()
+            });
+            assert_eq!(out.found, 250, "mode {mode}: every kept/tail document contains \"mouse\"");
+            assert!(out.found_is_exact, "mode {mode}: a full window must never leave found_is_exact false");
+        }
+    }
+
+    #[test]
+    fn disjunctive_pruning_genuinely_undercounts_a_hopeless_tail() {
+        // The regression test for the exact gap caught during design review:
+        // a single-token query has only one frontier, so without the
+        // driver's self-skip branch (the `None`-pivot case in
+        // `run_disjunctive`), that frontier's own hopeless block would never
+        // be skipped whole — it would always fall back to visiting doc by
+        // doc, and `found` would stay exact no matter how small `limit` is.
+        let docs = skewed_block_corpus(1000, 128, 20, 122);
+        let f = SegmentFixture::new(&docs);
+        let small = f.search(SearchParams {
+            q: Some("mouse".into()),
+            prefix: Some(false),
+            query_by: Some("title".into()),
+            match_mode: Some("any".into()),
+            limit: Some(5),
+            ..Default::default()
+        });
+        let large = f.search(SearchParams {
+            q: Some("mouse".into()),
+            prefix: Some(false),
+            query_by: Some("title".into()),
+            match_mode: Some("any".into()),
+            limit: Some(250),
+            ..Default::default()
+        });
+
+        assert_eq!(large.found, 250, "the reference run is unpruned: every kept/tail doc contains \"mouse\"");
+        assert!(large.found_is_exact);
+
+        assert!(!small.found_is_exact, "a genuinely hopeless block must have been skipped");
+        assert!(
+            small.found < large.found,
+            "small.found={} must genuinely undercount large.found={}",
+            small.found,
+            large.found
+        );
+
+        // Pruning must not corrupt ranking, only the count of the tail it
+        // never visited.
+        let small_ids: Vec<DocId> = small.hits.iter().map(|h| h.doc_id).collect();
+        let large_top5: Vec<DocId> = large.hits.iter().take(5).map(|h| h.doc_id).collect();
+        assert_eq!(small_ids, large_top5);
+    }
+
+    #[test]
+    fn conjunctive_pruning_genuinely_undercounts_a_hopeless_tail() {
+        // Same shape, `All` mode (the default) with two tokens that always
+        // co-occur — proving the hybrid leapfrog+bound-skip driver
+        // (`run_conjunctive`) also skips and also undercounts, not just
+        // `run_disjunctive`. This is the test proving the Context section's
+        // decision to extend real pruning to `All` was actually implemented.
+        let docs = skewed_block_corpus_two_tokens(1000, 128, 20, 122);
+        let f = SegmentFixture::new(&docs);
+        let small = f.search(SearchParams {
+            q: Some("mouse pad".into()),
+            prefix: Some(false),
+            query_by: Some("title".into()),
+            limit: Some(5),
+            ..Default::default()
+        });
+        let large = f.search(SearchParams {
+            q: Some("mouse pad".into()),
+            prefix: Some(false),
+            query_by: Some("title".into()),
+            limit: Some(250),
+            ..Default::default()
+        });
+
+        assert_eq!(large.found, 250, "every kept/tail doc contains both tokens, always together");
+        assert!(large.found_is_exact);
+        assert!(!small.found_is_exact, "a genuinely hopeless block must have been skipped");
+        assert!(
+            small.found < large.found,
+            "small.found={} must genuinely undercount large.found={}",
+            small.found,
+            large.found
+        );
+
+        let small_ids: Vec<DocId> = small.hits.iter().map(|h| h.doc_id).collect();
+        let large_top5: Vec<DocId> = large.hits.iter().take(5).map(|h| h.doc_id).collect();
+        assert_eq!(small_ids, large_top5);
+    }
+
+    #[test]
+    fn conjunctive_correctness_when_not_skipped() {
+        // A moderate, single-block corpus with a large enough window that
+        // theta stays -infinity throughout (no bound ever dips below it, so
+        // neither the bound-skip nor the leapfrog phase ever needs to
+        // reject a genuine candidate) — an exact-intersection sanity check
+        // for `All` mode's leapfrog agreement alone.
+        let mut docs = Vec::new();
+        for i in 0..30 {
+            let mut words = Vec::new();
+            if i % 2 == 0 {
+                words.push("wireless");
+            }
+            if i % 3 == 0 {
+                words.push("mouse");
+            }
+            if words.is_empty() {
+                words.push("filler");
+            }
+            docs.push(json!({"id": i.to_string(), "title": words.join(" "), "description": "d"}));
+        }
+        let f = Fixture::new(&docs);
+        let out = f.search(SearchParams {
+            q: Some("wireless mouse".into()),
+            prefix: Some(false),
+            query_by: Some("title".into()),
+            limit: Some(30),
+            ..Default::default()
+        });
+
+        let expected: Vec<DocId> = (0..30).filter(|i| i % 6 == 0).collect();
+        let mut found_ids: Vec<DocId> = out.matched.iter().collect();
+        found_ids.sort_unstable();
+        assert_eq!(found_ids, expected, "the hand-computed AND of both per-token match sets");
+        assert!(out.found_is_exact);
+    }
+
+    #[test]
+    fn multi_candidate_aggregation_keeps_max_score_and_min_edits_independently() {
+        // One document matched by two candidates of the same query token:
+        // the exact term "wireless" (edits=0, tf=1, so a small contribution)
+        // and a one-edit typo "wirelesss" (edits=1, tf=10, so a much larger
+        // contribution) — both terms occur only in this document, so they
+        // share the same idf and the difference is purely from tf. Max BM25
+        // must pick the typo'd candidate's larger contribution, but the
+        // exact candidate's lower edit distance must still be recorded,
+        // independently of which candidate produced the winning score. A
+        // single document, single field, single token corpus never fills
+        // any window, so this isolates aggregation from any pruning.
+        let mut words = vec!["wireless".to_string()];
+        words.extend(std::iter::repeat_n("wirelesss".to_string(), 10));
+        let f = Fixture::new(&[json!({"id": "1", "title": words.join(" "), "description": ""})]);
+
+        let out = f.search(SearchParams {
+            q: Some("wireless".into()),
+            prefix: Some(false),
+            query_by: Some("title".into()),
+            limit: Some(1),
+            ..Default::default()
+        });
+
+        assert_eq!(out.found, 1);
+        assert_eq!(
+            out.hits[0].components.typo_penalty, 1.0,
+            "min edits (0, from the exact candidate) must win independently of which candidate scored higher"
+        );
+    }
+
+    #[test]
+    fn multi_source_merge_spans_a_segment_and_the_memtable() {
+        // A term whose postings span both a segment (the low doc ids, from
+        // a prior flush) and the memtable (the high doc ids, written since)
+        // — exercising `MergeCursor`'s union merge across a real source
+        // boundary, not just within one source.
+        let schema = schema();
+        let mut flushed = MemTable::new(0, &schema);
+        for i in 0..5 {
+            flushed.insert(
+                ParsedDocument::parse(
+                    json!({"id": i.to_string(), "title": "mouse", "description": "d"}),
+                    &schema,
+                )
+                .unwrap(),
+            );
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let encoded = tachyon_index::encode(&flushed, &schema).unwrap();
+        let paths = tachyon_index::SegmentFilePaths {
+            terms: dir.path().join("seg.terms"),
+            ids: dir.path().join("seg.ids"),
+            post: dir.path().join("seg.post"),
+            col: dir.path().join("seg.col"),
+            doc: dir.path().join("seg.doc"),
+        };
+        std::fs::write(&paths.terms, &encoded.terms).unwrap();
+        std::fs::write(&paths.ids, &encoded.ids).unwrap();
+        std::fs::write(&paths.post, &encoded.post).unwrap();
+        std::fs::write(&paths.col, &encoded.col).unwrap();
+        std::fs::write(&paths.doc, &encoded.doc).unwrap();
+        let segment = tachyon_index::SegmentReader::open(&paths, &schema).unwrap();
+
+        // Doc ids keep incrementing across the flush boundary, never reused.
+        let mut live = MemTable::new(5, &schema);
+        for i in 5..10 {
+            live.insert(
+                ParsedDocument::parse(
+                    json!({"id": i.to_string(), "title": "mouse", "description": "d"}),
+                    &schema,
+                )
+                .unwrap(),
+            );
+        }
+
+        let deleted = RoaringBitmap::new();
+        let ctx = SearchContext::new(&schema, vec![&live, &segment], &deleted);
+        let req = SearchRequest::resolve(
+            SearchParams {
+                q: Some("mouse".into()),
+                prefix: Some(false),
+                query_by: Some("title".into()),
+                limit: Some(10),
+                ..Default::default()
+            },
+            &schema,
+        )
+        .unwrap();
+        let out = execute(&ctx, &req);
+
+        assert_eq!(out.found, 10);
+        assert!(out.found_is_exact);
+        let mut ids: Vec<DocId> = out.matched.iter().collect();
+        ids.sort_unstable();
+        assert_eq!(ids, (0..10).collect::<Vec<DocId>>());
+    }
+
+    /// `Collection::merge_locked` (`tachyon-engine`) makes the active
+    /// memtable reserve (`MemTable::reserve`) the exact doc id range a
+    /// merge's output segment just claimed, so its next real insert doesn't
+    /// collide with it — but that reservation makes the memtable *declare*
+    /// (`min_doc_id()..end_doc_id()`) the very same range the segment owns,
+    /// even though nothing is ever live in the memtable's copy of it.
+    /// `SearchContext::is_live`/`field_len` used to stop at the first
+    /// range-matching source (see their doc comments), so a document
+    /// genuinely live in the second, real-owning source was reported dead
+    /// and silently dropped from every search — this reproduces that shape
+    /// directly against `SearchContext`, without needing a real merge.
+    #[test]
+    fn search_context_falls_through_a_hole_only_source_to_the_real_owner() {
+        let schema = schema();
+
+        let mut holes = MemTable::new(0, &schema);
+        holes.reserve(5); // declares 0..5, nothing live in any of it
+
+        let mut owner = MemTable::new(0, &schema);
+        for i in 0..5 {
+            owner.insert(
+                ParsedDocument::parse(
+                    json!({"id": i.to_string(), "title": "mouse", "description": "d"}),
+                    &schema,
+                )
+                .unwrap(),
+            );
+        }
+
+        let deleted = RoaringBitmap::new();
+        // `holes` first, matching `Collection::sources()`'s own
+        // memtable-before-every-segment order — the shape that actually
+        // broke, since `.find()`/`.any()` walk sources in this order.
+        let ctx = SearchContext::new(&schema, vec![&holes, &owner], &deleted);
+
+        for doc_id in 0..5 {
+            assert!(ctx.is_live(doc_id), "doc {doc_id} is live in the second, real-owning source");
+            assert!(ctx.field_len(doc_id, 0) > 0, "doc {doc_id}'s length must come from the real owner");
+            assert!(ctx.value(doc_id, 0).is_some(), "doc {doc_id}'s value must come from the real owner");
+        }
+
+        let req = SearchRequest::resolve(
+            SearchParams {
+                q: Some("mouse".into()),
+                prefix: Some(false),
+                query_by: Some("title".into()),
+                limit: Some(10),
+                ..Default::default()
+            },
+            &schema,
+        )
+        .unwrap();
+        let out = execute(&ctx, &req);
+        assert_eq!(out.found, 5, "every document behind the hole-only source must still be found");
+    }
+
+    #[test]
+    fn found_is_exact_correctness_matrix() {
+        // Small corpus, never fills the window: exact in both modes.
+        let f = corpus();
+        let any = f.search(SearchParams { match_mode: Some("any".into()), ..query("mouse") });
+        let all = f.search(SearchParams { match_mode: Some("all".into()), ..query("mouse") });
+        assert!(any.found_is_exact, "small corpus, any mode");
+        assert!(all.found_is_exact, "small corpus, all mode");
+
+        // A field-only sort disables pruning entirely, regardless of corpus
+        // size — reusing `pruning_is_bypassed_for_a_field_only_sort`'s shape.
+        let mut docs = vec![json!({
+            "id": "winner", "title": "desk accessory", "description": "a mouse pad, barely",
+            "popularity": 0,
+        })];
+        for i in 0..30 {
+            docs.push(json!({
+                "id": format!("filler{i}"),
+                "title": "mouse mouse mouse mouse mouse",
+                "description": "mouse mouse mouse",
+                "popularity": 100 + i,
+            }));
+        }
+        let sorted_out = Fixture::new(&docs).search(SearchParams {
+            sort: Some("popularity:asc".into()),
+            limit: Some(3),
+            match_mode: Some("any".into()),
+            ..query("mouse")
+        });
+        assert!(sorted_out.found_is_exact, "a field-only sort never prunes");
+
+        // A window-filling query that genuinely skips: false, in either mode.
+        let seg = SegmentFixture::new(&skewed_block_corpus(1000, 128, 20, 122));
+        for mode in ["any", "all"] {
+            let out = seg.search(SearchParams {
+                q: Some("mouse".into()),
+                prefix: Some(false),
+                query_by: Some("title".into()),
+                match_mode: Some(mode.into()),
+                limit: Some(5),
+                ..Default::default()
+            });
+            assert!(!out.found_is_exact, "mode {mode}: a window-filling query that genuinely skips");
+        }
     }
 }

--- a/crates/tachyon-query/src/lib.rs
+++ b/crates/tachyon-query/src/lib.rs
@@ -14,6 +14,7 @@ pub mod request;
 pub mod score;
 pub mod sort;
 pub mod suggest;
+mod wand;
 
 pub use executor::{execute, ScoredDoc, SearchContext, SearchOutcome};
 pub use facets::compute as compute_facets;

--- a/crates/tachyon-query/src/request.rs
+++ b/crates/tachyon-query/src/request.rs
@@ -212,6 +212,14 @@ pub struct Hit {
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct SearchResponse {
     pub found: usize,
+    /// `false` iff pruning skipped at least one block of at least one
+    /// term's postings while answering this query — for EITHER match mode;
+    /// the exactness guarantee is tied to whether a skip occurred, not to
+    /// `match_mode`. Conservative: may occasionally read `false` when a
+    /// skipped region held no additional matches, never `true` when a skip
+    /// occurred. Always serialized (no `skip_serializing_if`) — unlike
+    /// `facets`, this is meaningful on every response.
+    pub found_is_exact: bool,
     pub search_time_ms: u64,
     pub hits: Vec<Hit>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/tachyon-query/src/wand.rs
+++ b/crates/tachyon-query/src/wand.rs
@@ -1,0 +1,870 @@
+//! True block-max WAND: a document-at-a-time postings walk that skips whole
+//! blocks — sometimes whole documents — when a sound bound proves they
+//! cannot affect the top-K, rather than merely skipping the expensive tail
+//! of scoring for documents already visited (that's the older, still-active
+//! "scoped" mechanism in `executor.rs`; the two are deliberately named and
+//! kept apart — see `executor.rs`'s module doc for how they compose).
+//!
+//! # Shape
+//!
+//! ```text
+//! per-token candidate terms -> per-source cursors -> MergeCursor (one per
+//! candidate, across sources) -> FieldCandidates (one per query_by field,
+//! across candidates) -> TokenFrontier (one per query token, across fields)
+//! -> a driver (run_disjunctive or run_conjunctive) that decides, block by
+//! block, which documents are even worth resolving -> DocEvidence (one
+//! visited document's per-field, per-token matches) -> DocScorer (the old
+//! finish()'s per-document scoring body, reused verbatim in spirit)
+//! ```
+//!
+//! # Multi-candidate aggregation
+//!
+//! A query token can expand into several candidate terms (typo correction,
+//! prefix completion). When more than one candidate matches the same
+//! document in the same field, [`FieldCandidates::resolve`] keeps the
+//! *maximum* BM25 contribution, tracks the *minimum* edit distance
+//! independently of which candidate produced that best score, and *unions*
+//! every matching candidate's positions — bit-for-bit the same rule the
+//! pre-pruning accumulator used, so a query too small to trigger any bound
+//! check scores identically to before this file existed.
+
+use roaring::RoaringBitmap;
+
+use tachyon_core::{DocId, FieldId};
+use tachyon_index::{MergeCursor, PostingCursor};
+
+use crate::bm25::{self, FieldStats};
+use crate::executor::{sort_values, Ranked, SearchContext, TermCandidate, TopKByScore};
+use crate::query_text::ParsedQuery;
+use crate::request::SearchRequest;
+use crate::score::{self, ScoreComponents, ScoreWeights};
+
+/// One candidate term's postings, merged across every source, plus what it
+/// costs to score a match: `idf` (shared by every doc this candidate
+/// matches) and `edits` (this candidate's fixed distance from the original
+/// query token).
+struct CandidateCursor<'a> {
+    cursor: MergeCursor<'a>,
+    idf: f32,
+    edits: u32,
+}
+
+impl CandidateCursor<'_> {
+    /// Upper bound on this candidate's own BM25 contribution to whichever
+    /// doc it's currently positioned at (or the block it's in, for a
+    /// block-structured source).
+    fn score_bound(&self) -> f32 {
+        bm25::term_score_bound(self.cursor.max_remaining_tf(), self.idf)
+    }
+
+    fn contribution(&self, field_len: u32, stats: FieldStats) -> f32 {
+        bm25::term_score(self.cursor.term_freq(), field_len, stats, self.idf)
+    }
+}
+
+/// One query token's evidence in one queried field: the union, across every
+/// candidate term for that token, merged by doc id.
+struct FieldCandidates<'a> {
+    candidates: Vec<CandidateCursor<'a>>,
+}
+
+impl FieldCandidates<'_> {
+    fn doc_id(&self) -> Option<DocId> {
+        self.candidates.iter().filter_map(|c| c.cursor.doc_id()).min()
+    }
+
+    fn score_bound(&self) -> f32 {
+        self.candidates
+            .iter()
+            .filter(|c| c.cursor.doc_id().is_some())
+            .map(CandidateCursor::score_bound)
+            .fold(0.0, f32::max)
+    }
+
+    /// Min over every live candidate's own block boundary; `None` if any
+    /// live candidate lacks one (its `MergeCursor` has a live memtable
+    /// child) — same "any unbounded source makes the whole bound unsound"
+    /// rule `MergeCursor` itself follows one level down.
+    fn current_block_last_doc_id(&self) -> Option<DocId> {
+        let mut min: Option<DocId> = None;
+        for c in &self.candidates {
+            if c.cursor.doc_id().is_none() {
+                continue;
+            }
+            let last = c.cursor.current_block_last_doc_id()?;
+            min = Some(min.map_or(last, |m| m.min(last)));
+        }
+        min
+    }
+
+    /// This token's resolved match in this field at `doc_id`, or `None` if
+    /// no candidate is present there. See this module's doc comment for the
+    /// exact multi-candidate aggregation rule this implements.
+    fn resolve(
+        &self,
+        doc_id: DocId,
+        field_len: u32,
+        stats: FieldStats,
+        needs_positions: bool,
+    ) -> Option<FieldMatch> {
+        let mut best_contribution = 0.0f32;
+        let mut best_edits = u32::MAX;
+        let mut positions = Vec::new();
+        let mut matched = false;
+
+        for c in &self.candidates {
+            if c.cursor.doc_id() != Some(doc_id) {
+                continue;
+            }
+            matched = true;
+            let contribution = c.contribution(field_len, stats);
+            if contribution > best_contribution {
+                best_contribution = contribution;
+            }
+            if c.edits < best_edits {
+                best_edits = c.edits;
+            }
+            if needs_positions {
+                positions.extend(c.cursor.positions());
+            }
+        }
+
+        matched.then_some(FieldMatch { contribution: best_contribution, edits: best_edits, positions })
+    }
+}
+
+/// One query token's evidence across every field in `query_by` — the unit
+/// the pruning driver operates on, one per token.
+pub(crate) struct TokenFrontier<'a> {
+    fields: Vec<FieldCandidates<'a>>,
+}
+
+impl TokenFrontier<'_> {
+    fn doc_id(&self) -> Option<DocId> {
+        self.fields.iter().filter_map(FieldCandidates::doc_id).min()
+    }
+
+    /// Max-over-fields of each field's bound: only one field ultimately
+    /// wins a document, so summing across fields would be needlessly loose.
+    /// Summing THESE per-token bounds across tokens (the drivers' job) is
+    /// still sound — max(sum) <= sum(max) — though looser than tracking
+    /// per-field consistency across tokens; the scoped mechanism already
+    /// accepts the same looseness via its own global `max_field_boost`.
+    fn score_bound(&self) -> f32 {
+        self.fields.iter().map(FieldCandidates::score_bound).fold(0.0, f32::max)
+    }
+
+    /// Min over every currently-live field's block boundary; a field with no
+    /// live candidate contributes nothing to a skip target and is excluded,
+    /// not treated as "no info".
+    fn current_block_last_doc_id(&self) -> Option<DocId> {
+        let mut min: Option<DocId> = None;
+        for f in &self.fields {
+            if f.doc_id().is_none() {
+                continue;
+            }
+            let last = f.current_block_last_doc_id()?;
+            min = Some(min.map_or(last, |m| m.min(last)));
+        }
+        min
+    }
+
+    /// Advance every candidate, in every field, currently sitting at this
+    /// frontier's own current (smallest) doc id.
+    fn advance(&mut self) {
+        let Some(current) = self.doc_id() else { return };
+        for f in &mut self.fields {
+            for c in &mut f.candidates {
+                if c.cursor.doc_id() == Some(current) {
+                    c.cursor.advance();
+                }
+            }
+        }
+    }
+
+    fn advance_to(&mut self, target: DocId) {
+        for f in &mut self.fields {
+            for c in &mut f.candidates {
+                if c.cursor.doc_id().is_some_and(|d| d < target) {
+                    c.cursor.advance_to(target);
+                }
+            }
+        }
+    }
+}
+
+/// Build one frontier per query token. `idf`/candidate resolution mirrors
+/// what the pre-pruning walk did inline — only now the result is a cursor to
+/// be driven lazily, not an immediate fold into an accumulator. A
+/// candidate/field/source combination with no postings anywhere is omitted
+/// entirely, same as the old walk's `doc_freq == 0 { continue; }`.
+pub(crate) fn build_frontiers<'a>(
+    ctx: &'a SearchContext<'a>,
+    req: &SearchRequest,
+    expansions: &[Vec<TermCandidate>],
+) -> Vec<TokenFrontier<'a>> {
+    expansions
+        .iter()
+        .map(|candidates| {
+            let fields = req
+                .query_by
+                .iter()
+                .map(|&(field, _boost)| {
+                    let stats = ctx.field_stats(field);
+                    if stats.doc_count == 0 {
+                        return FieldCandidates { candidates: Vec::new() };
+                    }
+
+                    let mut field_candidates = Vec::new();
+                    for candidate in candidates {
+                        let doc_freq: u32 =
+                            ctx.sources.iter().map(|s| s.doc_freq(&candidate.term, field)).sum();
+                        if doc_freq == 0 {
+                            continue;
+                        }
+                        let idf = bm25::idf(doc_freq, stats.doc_count);
+                        let children: Vec<Box<dyn PostingCursor + 'a>> = ctx
+                            .sources
+                            .iter()
+                            .filter_map(|s| s.posting_cursor(&candidate.term, field))
+                            .collect();
+                        field_candidates.push(CandidateCursor {
+                            cursor: MergeCursor::new(children),
+                            idf,
+                            edits: candidate.edits,
+                        });
+                    }
+                    FieldCandidates { candidates: field_candidates }
+                })
+                .collect();
+            TokenFrontier { fields }
+        })
+        .collect()
+}
+
+/// The bound a pivot/threshold check compares against theta: a real or
+/// bound BM25 value, normalized, combined with the maximum possible value
+/// of every other `combine()` component. Sound because `combine()` is
+/// non-decreasing in each component — shared by both drivers here and by
+/// the older scoped-pruning mechanism in `executor.rs`, which uses the
+/// identical formula on an already-exact (not bound) BM25 sum.
+fn bound_to_combined_score(bm25_bound: f32, scorer: &DocScorer) -> f32 {
+    ScoreComponents {
+        bm25: score::normalize_bm25(bm25_bound),
+        field_boost: scorer.max_field_boost,
+        proximity: 1.0,
+        typo_penalty: 1.0,
+        popularity: 1.0,
+    }
+    .combine(&scorer.weights)
+}
+
+/// One matched (token, field) cell: the winning candidate's contribution and
+/// edit distance, and the union of every matching candidate's positions —
+/// see this module's doc comment for the exact aggregation rule.
+struct FieldMatch {
+    contribution: f32,
+    edits: u32,
+    positions: Vec<u32>,
+}
+
+/// One document's evidence, gathered by resolving every token's frontier at
+/// that doc id. Mirrors the retired `Accumulator`'s per-slot API, but for a
+/// single document — the pruning walk visits one document at a time rather
+/// than building a flat table across every match up front.
+struct DocEvidence {
+    /// `[field_pos][token_idx]`.
+    matches: Vec<Vec<Option<FieldMatch>>>,
+}
+
+impl DocEvidence {
+    fn matched(&self, field: usize, token: usize) -> bool {
+        self.matches[field][token].is_some()
+    }
+
+    fn field_bm25(&self, field: usize) -> f32 {
+        self.matches[field].iter().filter_map(|m| m.as_ref()).map(|m| m.contribution).sum()
+    }
+
+    fn field_edits(&self, field: usize) -> u32 {
+        self.matches[field].iter().filter_map(|m| m.as_ref()).map(|m| m.edits).sum()
+    }
+
+    fn field_matched_tokens(&self, field: usize) -> usize {
+        self.matches[field].iter().filter(|m| m.is_some()).count()
+    }
+
+    /// Sorted, deduplicated positions of one token in one field. Valid only
+    /// after [`DocEvidence::normalize_positions`].
+    fn token_positions(&self, field: usize, token: usize) -> &[u32] {
+        self.matches[field][token].as_ref().map_or(&[], |m| m.positions.as_slice())
+    }
+
+    /// Put every position list into sorted, deduplicated form, same as the
+    /// retired accumulator's own pass — positions arrive out of order
+    /// because one token can expand into several candidates, each
+    /// contributing its own occurrences.
+    fn normalize_positions(&mut self) {
+        for row in &mut self.matches {
+            for m in row.iter_mut().flatten() {
+                if m.positions.len() > 1 {
+                    m.positions.sort_unstable();
+                    m.positions.dedup();
+                }
+            }
+        }
+    }
+}
+
+/// Everything needed to resolve and score one document, gathered once
+/// before either driver runs.
+pub(crate) struct DocScorer<'a> {
+    ctx: &'a SearchContext<'a>,
+    req: &'a SearchRequest,
+    filter: Option<&'a RoaringBitmap>,
+    weights: ScoreWeights,
+    max_boost: f32,
+    max_field_boost: f32,
+    allowed_edits: u32,
+    popularity_field: Option<FieldId>,
+    needs_positions: bool,
+    num_tokens: usize,
+    /// Corpus stats per `query_by` field, computed once — BM25 needs global
+    /// numbers, and recomputing them per document would repeat the same
+    /// O(num_sources) sum for every match a broad query visits.
+    field_stats: Vec<FieldStats>,
+}
+
+impl<'a> DocScorer<'a> {
+    pub(crate) fn new(
+        ctx: &'a SearchContext<'a>,
+        req: &'a SearchRequest,
+        filter: Option<&'a RoaringBitmap>,
+        allowed_edits: u32,
+        needs_positions: bool,
+        num_tokens: usize,
+    ) -> DocScorer<'a> {
+        let max_boost = score::max_boost(ctx.schema);
+        let max_field_boost = req
+            .query_by
+            .iter()
+            .map(|&(_, boost)| score::normalize_field_boost(boost, max_boost))
+            .fold(0.0f32, f32::max);
+        let popularity_field = ctx.schema.field(score::POPULARITY_FIELD).map(|(id, _)| id);
+        let field_stats = req.query_by.iter().map(|&(field, _)| ctx.field_stats(field)).collect();
+        DocScorer {
+            ctx,
+            req,
+            filter,
+            weights: ScoreWeights::default(),
+            max_boost,
+            max_field_boost,
+            allowed_edits,
+            popularity_field,
+            needs_positions,
+            num_tokens,
+            field_stats,
+        }
+    }
+
+    /// Resolve every token's frontier at `doc_id` into one document's
+    /// evidence. Positions are decoded only for candidates actually
+    /// present at this exact doc id — never for a block or document a
+    /// driver already decided to skip.
+    fn resolve(&self, frontiers: &[TokenFrontier], doc_id: DocId) -> DocEvidence {
+        let mut matches = Vec::with_capacity(self.req.query_by.len());
+        for (field_pos, &(field, _boost)) in self.req.query_by.iter().enumerate() {
+            let field_len = self.ctx.field_len(doc_id, field);
+            let stats = self.field_stats[field_pos];
+            let row: Vec<Option<FieldMatch>> = frontiers
+                .iter()
+                .map(|frontier| {
+                    frontier.fields[field_pos].resolve(doc_id, field_len, stats, self.needs_positions)
+                })
+                .collect();
+            matches.push(row);
+        }
+        let mut evidence = DocEvidence { matches };
+        evidence.normalize_positions();
+        evidence
+    }
+
+    /// The old `finish()`'s per-slot scoring body, unchanged in substance:
+    /// best-field selection, proximity, popularity, `combine()`, and a push
+    /// into the kept set — still gated by the older *scoped* mechanism's
+    /// own exact-bm25-bound check, which this preserves verbatim as an
+    /// inner layer beneath the driver's own (block-level, bound-only)
+    /// pruning.
+    fn score(
+        &self,
+        doc_id: DocId,
+        evidence: &DocEvidence,
+        top_k: &mut Option<TopKByScore>,
+        candidates: &mut Vec<Ranked>,
+    ) {
+        let num_fields = self.req.query_by.len();
+        let bm25_bound = (0..num_fields).map(|f| evidence.field_bm25(f)).fold(0.0f32, f32::max);
+
+        if let Some(tk) = top_k.as_ref() {
+            if let Some(threshold) = tk.threshold() {
+                if bound_to_combined_score(bm25_bound, self) < threshold {
+                    // Provably cannot beat the current worst-of-the-kept-set;
+                    // already counted by the caller.
+                    return;
+                }
+            }
+        }
+
+        let mut best_field = 0usize;
+        let mut best_bm25 = 0.0f32;
+        let mut best_boosted = f32::NEG_INFINITY;
+        for field_pos in 0..num_fields {
+            let raw = evidence.field_bm25(field_pos);
+            let boosted = raw * self.req.query_by[field_pos].1;
+            if boosted > best_boosted {
+                best_boosted = boosted;
+                best_bm25 = raw;
+                best_field = field_pos;
+            }
+        }
+
+        let present: Vec<&[u32]> = (0..self.num_tokens)
+            .filter(|&token| evidence.matched(best_field, token))
+            .map(|token| evidence.token_positions(best_field, token))
+            .collect();
+
+        let matched_here = evidence.field_matched_tokens(best_field);
+        let proximity = if matched_here == self.num_tokens {
+            score::proximity(&present)
+        } else {
+            // A partial match in this field cannot claim tight proximity.
+            score::proximity(&present) * matched_here as f32 / self.num_tokens as f32
+        };
+
+        let popularity = self
+            .popularity_field
+            .and_then(|f| self.ctx.value(doc_id, f))
+            .and_then(|v| v.as_f64())
+            .map(|v| score::normalize_popularity(v as f32))
+            .unwrap_or(0.0);
+
+        let components = ScoreComponents {
+            bm25: score::normalize_bm25(best_bm25),
+            field_boost: score::normalize_field_boost(self.req.query_by[best_field].1, self.max_boost),
+            proximity,
+            typo_penalty: score::typo_penalty(evidence.field_edits(best_field), self.allowed_edits),
+            popularity,
+        };
+
+        let score = components.combine(&self.weights);
+        let ranked = Ranked {
+            doc_id,
+            score,
+            components,
+            sort_values: sort_values(self.ctx, self.req, doc_id, score),
+        };
+        match top_k {
+            Some(tk) => tk.push(ranked),
+            None => candidates.push(ranked),
+        }
+    }
+}
+
+/// Whether some single field places every phrase's tokens consecutively.
+///
+/// A phrase must be satisfied within one field — `title` ending in "mouse"
+/// and `description` starting with "pad" is not the phrase "mouse pad".
+fn satisfies_phrases(evidence: &DocEvidence, req: &SearchRequest, phrases: &[(usize, usize)]) -> bool {
+    phrases
+        .iter()
+        .all(|&(start, end)| (0..req.query_by.len()).any(|field| phrase_in_field(evidence, field, start, end)))
+}
+
+fn phrase_in_field(evidence: &DocEvidence, field: usize, start: usize, end: usize) -> bool {
+    // Every token of the phrase has to be present in this field at all.
+    if (start..=end).any(|token| !evidence.matched(field, token)) {
+        return false;
+    }
+
+    // Walk the first token's positions; each is a candidate phrase start.
+    let first = evidence.token_positions(field, start);
+
+    first.iter().any(|&anchor| {
+        (start + 1..=end).enumerate().all(|(offset, token)| {
+            let positions = evidence.token_positions(field, token);
+            anchor
+                .checked_add(offset as u32 + 1)
+                .is_some_and(|expected| positions.binary_search(&expected).is_ok())
+        })
+    })
+}
+
+/// Resolve one candidate document: liveness, tombstones, and the request
+/// filter first (cheapest checks, applied before any positions are ever
+/// decoded), then the phrase gate, then — if it survives both — scoring.
+/// Always pushes into `matched_ids` if it clears the phrase gate, matching
+/// `found`'s existing definition; a document a bound proved not worth
+/// visiting never reaches this function at all, which is the only source of
+/// approximation.
+#[allow(clippy::too_many_arguments)]
+fn visit_and_score(
+    doc_id: DocId,
+    frontiers: &[TokenFrontier],
+    query: &ParsedQuery,
+    scorer: &DocScorer,
+    matched_ids: &mut Vec<DocId>,
+    top_k: &mut Option<TopKByScore>,
+    candidates: &mut Vec<Ranked>,
+) {
+    if !scorer.ctx.is_live(doc_id) || scorer.filter.is_some_and(|f| !f.contains(doc_id)) {
+        return;
+    }
+
+    let evidence = scorer.resolve(frontiers, doc_id);
+
+    if !query.phrases.is_empty() && !satisfies_phrases(&evidence, scorer.req, &query.phrases) {
+        return;
+    }
+
+    matched_ids.push(doc_id);
+    if scorer.req.window() == 0 {
+        return;
+    }
+
+    scorer.score(doc_id, &evidence, top_k, candidates);
+}
+
+/// `MatchMode::Any`: a document qualifies as soon as ANY one token's
+/// frontier reaches it — WAND's classic pivot selection, generalized so the
+/// pivot doesn't have to be a genuine intersection candidate, just whichever
+/// doc id a running sum of *live* frontiers' bounds first clears theta at.
+///
+/// Returns the ascending doc ids visited and pushed into `matched_ids`
+/// (already reflected in the caller-owned `matched_ids` — see below), and
+/// whether any postings were skipped without being visited.
+pub(crate) fn run_disjunctive(
+    frontiers: &mut [TokenFrontier],
+    query: &ParsedQuery,
+    scorer: &DocScorer,
+    top_k: &mut Option<TopKByScore>,
+    candidates: &mut Vec<Ranked>,
+) -> (Vec<DocId>, bool) {
+    let mut matched_ids = Vec::new();
+    let mut any_skip = false;
+
+    loop {
+        let mut live: Vec<usize> =
+            (0..frontiers.len()).filter(|&i| frontiers[i].doc_id().is_some()).collect();
+        if live.is_empty() {
+            break;
+        }
+        live.sort_by_key(|&i| frontiers[i].doc_id().unwrap());
+
+        let theta = top_k.as_ref().and_then(TopKByScore::threshold).unwrap_or(f32::NEG_INFINITY);
+
+        let mut acc_bound = 0.0f32;
+        let mut pivot: Option<usize> = None; // index into `live`
+        for (pos, &i) in live.iter().enumerate() {
+            acc_bound += frontiers[i].score_bound();
+            if bound_to_combined_score(acc_bound, scorer) >= theta {
+                pivot = Some(pos);
+                break;
+            }
+        }
+
+        match pivot {
+            Some(pos) => {
+                let pivot_doc = frontiers[live[pos]].doc_id().unwrap();
+                if pivot_doc > frontiers[live[0]].doc_id().unwrap() {
+                    any_skip = true;
+                    for &i in &live[..pos] {
+                        frontiers[i].advance_to(pivot_doc);
+                    }
+                }
+
+                visit_and_score(pivot_doc, frontiers, query, scorer, &mut matched_ids, top_k, candidates);
+
+                for &i in &live {
+                    if frontiers[i].doc_id() == Some(pivot_doc) {
+                        frontiers[i].advance();
+                    }
+                }
+            }
+            None => {
+                // Not even summing every live frontier's current-block bound
+                // clears theta: nothing up to the nearest block boundary
+                // among them can possibly matter. With a SINGLE live
+                // frontier (a single-token query, or several tokens whose
+                // lists happen to be fully aligned) this is the ONLY way
+                // that frontier's own hopeless block ever gets skipped
+                // whole, rather than visited document by document.
+                any_skip = true;
+                let skip_to =
+                    live.iter().filter_map(|&i| frontiers[i].current_block_last_doc_id()).min();
+                for &i in &live {
+                    match skip_to {
+                        Some(d) => frontiers[i].advance_to(d.saturating_add(1)),
+                        None => {
+                            frontiers[i].advance();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    (matched_ids, any_skip)
+}
+
+/// `MatchMode::All`: every token is required, so a genuine match needs a
+/// contribution from every frontier. Two phases run every iteration, in
+/// this order:
+///
+/// 1. **Bound check** — sum every frontier's current-block bound; if that
+///    can't clear theta, nothing up to the nearest shared block boundary
+///    can possibly matter, so skip ahead without searching for agreement at
+///    all.
+/// 2. **Exact leapfrog** — find the next doc id every frontier agrees on.
+///    Every `advance_to` here targets a KNOWN required position (another
+///    frontier's current doc id), so nothing skipped during this phase can
+///    be a genuine intersection member; this phase alone is always exact.
+///
+/// The order matters: checking the bound *before* searching for agreement
+/// is what lets a hopeless region be skipped without ever being searched —
+/// checking after would mean every visited-but-rejected document still paid
+/// the full leapfrog cost, which is the entire latency win for `All`-mode
+/// broad queries, including the single-token case (one frontier, its own
+/// block bound and block boundary — degenerates correctly, same as
+/// [`run_disjunctive`]'s `None` branch).
+pub(crate) fn run_conjunctive(
+    frontiers: &mut [TokenFrontier],
+    query: &ParsedQuery,
+    scorer: &DocScorer,
+    top_k: &mut Option<TopKByScore>,
+    candidates: &mut Vec<Ranked>,
+) -> (Vec<DocId>, bool) {
+    let mut matched_ids = Vec::new();
+    let mut any_skip = false;
+
+    loop {
+        if frontiers.iter().any(|f| f.doc_id().is_none()) {
+            break; // one required list exhausted -> the intersection is done
+        }
+
+        let theta = top_k.as_ref().and_then(TopKByScore::threshold).unwrap_or(f32::NEG_INFINITY);
+        let bound_sum: f32 = frontiers.iter().map(TokenFrontier::score_bound).sum();
+        if bound_to_combined_score(bound_sum, scorer) < theta {
+            any_skip = true;
+            let skip_to = frontiers.iter().filter_map(TokenFrontier::current_block_last_doc_id).min();
+            for f in frontiers.iter_mut() {
+                match skip_to {
+                    Some(d) => f.advance_to(d.saturating_add(1)),
+                    None => {
+                        f.advance();
+                    }
+                }
+            }
+            continue;
+        }
+
+        let max_doc = frontiers.iter().map(|f| f.doc_id().unwrap()).max().unwrap();
+        if frontiers.iter().all(|f| f.doc_id() == Some(max_doc)) {
+            // Genuine match, always counted: this phase alone is exact.
+            visit_and_score(max_doc, frontiers, query, scorer, &mut matched_ids, top_k, candidates);
+            for f in frontiers.iter_mut() {
+                f.advance();
+            }
+        } else {
+            for f in frontiers.iter_mut() {
+                if f.doc_id() != Some(max_doc) {
+                    f.advance_to(max_doc);
+                }
+            }
+        }
+    }
+
+    (matched_ids, any_skip)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde_json::json;
+    use tachyon_core::{CollectionSchema, FieldSchema, FieldType, ParsedDocument};
+    use tachyon_index::MemTable;
+
+    use crate::query_text;
+    use crate::request::{MatchMode, SearchParams};
+
+    fn schema() -> CollectionSchema {
+        CollectionSchema::new(
+            "products",
+            vec![
+                FieldSchema::new("title", FieldType::Text),
+                FieldSchema::new("description", FieldType::Text),
+            ],
+        )
+    }
+
+    fn build(docs: &[serde_json::Value]) -> (MemTable, CollectionSchema) {
+        let schema = schema();
+        let mut m = MemTable::new(0, &schema);
+        for d in docs {
+            m.insert(ParsedDocument::parse(d.clone(), &schema).unwrap());
+        }
+        (m, schema)
+    }
+
+    /// Exact-only expansions (no prefix/typo) — isolates frontier/driver
+    /// mechanics from query expansion, which the executor's own tests
+    /// already cover.
+    fn expansions_for(tokens: &[String]) -> Vec<Vec<TermCandidate>> {
+        tokens.iter().map(|t| vec![TermCandidate { term: t.clone(), edits: 0 }]).collect()
+    }
+
+    struct Outcome {
+        matched_ids: Vec<DocId>,
+        any_skip: bool,
+        hits: Vec<Ranked>,
+    }
+
+    fn run(m: &MemTable, schema: &CollectionSchema, q: &str, mode: MatchMode, limit: usize) -> Outcome {
+        let deleted = RoaringBitmap::new();
+        let ctx = SearchContext::new(schema, vec![m], &deleted);
+        let match_mode = match mode {
+            MatchMode::All => "all",
+            MatchMode::Any => "any",
+        };
+        let req = SearchRequest::resolve(
+            SearchParams {
+                q: Some(q.into()),
+                prefix: Some(false),
+                match_mode: Some(match_mode.into()),
+                limit: Some(limit),
+                ..Default::default()
+            },
+            schema,
+        )
+        .unwrap();
+
+        let query = query_text::parse(&req.q);
+        let expansions = expansions_for(&query.tokens);
+        let mut frontiers = build_frontiers(&ctx, &req, &expansions);
+        let needs_positions = query.tokens.len() > 1 || !query.phrases.is_empty();
+        let scorer = DocScorer::new(&ctx, &req, None, 0, needs_positions, query.tokens.len());
+        let mut top_k = Some(TopKByScore::new(req.window()));
+        let mut candidates = Vec::new();
+
+        let (matched_ids, any_skip) = match mode {
+            MatchMode::Any => {
+                run_disjunctive(&mut frontiers, &query, &scorer, &mut top_k, &mut candidates)
+            }
+            MatchMode::All => {
+                run_conjunctive(&mut frontiers, &query, &scorer, &mut top_k, &mut candidates)
+            }
+        };
+
+        Outcome { matched_ids, any_skip, hits: top_k.map_or(candidates, TopKByScore::into_vec) }
+    }
+
+    fn small_corpus() -> (MemTable, CollectionSchema) {
+        build(&[
+            json!({"id": "1", "title": "wireless mouse", "description": "a comfortable mouse"}),
+            json!({"id": "2", "title": "mechanical keyboard", "description": "loud and tactile"}),
+            json!({"id": "3", "title": "mouse pad", "description": "desk mat"}),
+            json!({"id": "4", "title": "wireless charger", "description": "charges phones"}),
+        ])
+    }
+
+    #[test]
+    fn disjunctive_matches_every_document_containing_any_token() {
+        let (m, schema) = small_corpus();
+        let out = run(&m, &schema, "wireless mouse", MatchMode::Any, 10);
+        let mut ids = out.matched_ids.clone();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![0, 2, 3], "wireless (0,3) or mouse (0,2) — union is docs 0,2,3");
+    }
+
+    #[test]
+    fn conjunctive_matches_only_documents_containing_every_token() {
+        let (m, schema) = small_corpus();
+        let out = run(&m, &schema, "wireless mouse", MatchMode::All, 10);
+        assert_eq!(out.matched_ids, vec![0], "only doc 0 has both terms");
+    }
+
+    #[test]
+    fn a_single_token_query_matches_under_both_modes() {
+        let (m, schema) = small_corpus();
+        let any = run(&m, &schema, "mouse", MatchMode::Any, 10);
+        let all = run(&m, &schema, "mouse", MatchMode::All, 10);
+        let mut any_ids = any.matched_ids.clone();
+        any_ids.sort_unstable();
+        let mut all_ids = all.matched_ids.clone();
+        all_ids.sort_unstable();
+        assert_eq!(any_ids, vec![0, 2]);
+        assert_eq!(all_ids, vec![0, 2]);
+    }
+
+    #[test]
+    fn a_full_window_never_skips_and_agrees_with_the_hit_count() {
+        let (m, schema) = small_corpus();
+        let out = run(&m, &schema, "mouse", MatchMode::Any, 10);
+        assert!(!out.any_skip, "a corpus this small never fills the window");
+        assert_eq!(out.matched_ids.len(), out.hits.len().max(out.matched_ids.len()));
+        assert_eq!(out.hits.len(), 2);
+    }
+
+    /// Enough documents, with enough score variation, that a small `limit`
+    /// genuinely exercises the disjunctive driver's bound checks — even with
+    /// no block structure at all (pure memtable), a document's own bound
+    /// can still fail to clear an already-full top-K's threshold, which is
+    /// what the driver's `None`-pivot branch is for.
+    fn broad_corpus(n: usize) -> (MemTable, CollectionSchema) {
+        let docs: Vec<serde_json::Value> = (0..n)
+            .map(|i| {
+                let repeats = (i % 7) + 1;
+                let title = vec!["mouse"; repeats].join(" ");
+                json!({"id": i.to_string(), "title": title, "description": "a mouse for the desk"})
+            })
+            .collect();
+        build(&docs)
+    }
+
+    #[test]
+    fn disjunctive_pruning_still_finds_the_correct_top_k() {
+        let (m, schema) = broad_corpus(60);
+        let small = run(&m, &schema, "mouse", MatchMode::Any, 5);
+        let large = run(&m, &schema, "mouse", MatchMode::Any, 60);
+
+        let mut small_ids: Vec<DocId> = small.hits.iter().map(|h| h.doc_id).collect();
+        let mut large_top5: Vec<DocId> = large.hits.iter().map(|h| h.doc_id).collect();
+        large_top5.sort_by(|a, b| {
+            let sa = large.hits.iter().find(|h| h.doc_id == *a).unwrap().score;
+            let sb = large.hits.iter().find(|h| h.doc_id == *b).unwrap().score;
+            sb.partial_cmp(&sa).unwrap().then(a.cmp(b))
+        });
+        large_top5.truncate(5);
+        small_ids.sort_by(|a, b| {
+            let sa = small.hits.iter().find(|h| h.doc_id == *a).unwrap().score;
+            let sb = small.hits.iter().find(|h| h.doc_id == *b).unwrap().score;
+            sb.partial_cmp(&sa).unwrap().then(a.cmp(b))
+        });
+        assert_eq!(small_ids, large_top5, "the small-window run must keep the true top 5");
+    }
+
+    #[test]
+    fn conjunctive_pruning_still_finds_the_correct_top_k() {
+        let (m, schema) = broad_corpus(60);
+        let small = run(&m, &schema, "mouse", MatchMode::All, 5);
+        let large = run(&m, &schema, "mouse", MatchMode::All, 60);
+
+        let top_ids = |o: &Outcome, k: usize| {
+            let mut hits = o.hits.clone();
+            hits.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap().then(a.doc_id.cmp(&b.doc_id)));
+            hits.truncate(k);
+            hits.into_iter().map(|h| h.doc_id).collect::<Vec<_>>()
+        };
+        assert_eq!(top_ids(&small, 5), top_ids(&large, 5));
+    }
+}

--- a/crates/tachyon-query/src/wand.rs
+++ b/crates/tachyon-query/src/wand.rs
@@ -129,7 +129,11 @@ impl FieldCandidates<'_> {
             }
         }
 
-        matched.then_some(FieldMatch { contribution: best_contribution, edits: best_edits, positions })
+        matched.then_some(FieldMatch {
+            contribution: best_contribution,
+            edits: best_edits,
+            positions,
+        })
     }
 }
 
@@ -379,7 +383,12 @@ impl<'a> DocScorer<'a> {
             let row: Vec<Option<FieldMatch>> = frontiers
                 .iter()
                 .map(|frontier| {
-                    frontier.fields[field_pos].resolve(doc_id, field_len, stats, self.needs_positions)
+                    frontier.fields[field_pos].resolve(
+                        doc_id,
+                        field_len,
+                        stats,
+                        self.needs_positions,
+                    )
                 })
                 .collect();
             matches.push(row);
@@ -450,7 +459,10 @@ impl<'a> DocScorer<'a> {
 
         let components = ScoreComponents {
             bm25: score::normalize_bm25(best_bm25),
-            field_boost: score::normalize_field_boost(self.req.query_by[best_field].1, self.max_boost),
+            field_boost: score::normalize_field_boost(
+                self.req.query_by[best_field].1,
+                self.max_boost,
+            ),
             proximity,
             typo_penalty: score::typo_penalty(evidence.field_edits(best_field), self.allowed_edits),
             popularity,
@@ -474,10 +486,14 @@ impl<'a> DocScorer<'a> {
 ///
 /// A phrase must be satisfied within one field — `title` ending in "mouse"
 /// and `description` starting with "pad" is not the phrase "mouse pad".
-fn satisfies_phrases(evidence: &DocEvidence, req: &SearchRequest, phrases: &[(usize, usize)]) -> bool {
-    phrases
-        .iter()
-        .all(|&(start, end)| (0..req.query_by.len()).any(|field| phrase_in_field(evidence, field, start, end)))
+fn satisfies_phrases(
+    evidence: &DocEvidence,
+    req: &SearchRequest,
+    phrases: &[(usize, usize)],
+) -> bool {
+    phrases.iter().all(|&(start, end)| {
+        (0..req.query_by.len()).any(|field| phrase_in_field(evidence, field, start, end))
+    })
 }
 
 fn phrase_in_field(evidence: &DocEvidence, field: usize, start: usize, end: usize) -> bool {
@@ -582,7 +598,15 @@ pub(crate) fn run_disjunctive(
                     }
                 }
 
-                visit_and_score(pivot_doc, frontiers, query, scorer, &mut matched_ids, top_k, candidates);
+                visit_and_score(
+                    pivot_doc,
+                    frontiers,
+                    query,
+                    scorer,
+                    &mut matched_ids,
+                    top_k,
+                    candidates,
+                );
 
                 for &i in &live {
                     if frontiers[i].doc_id() == Some(pivot_doc) {
@@ -655,7 +679,8 @@ pub(crate) fn run_conjunctive(
         let bound_sum: f32 = frontiers.iter().map(TokenFrontier::score_bound).sum();
         if bound_to_combined_score(bound_sum, scorer) < theta {
             any_skip = true;
-            let skip_to = frontiers.iter().filter_map(TokenFrontier::current_block_last_doc_id).min();
+            let skip_to =
+                frontiers.iter().filter_map(TokenFrontier::current_block_last_doc_id).min();
             for f in frontiers.iter_mut() {
                 match skip_to {
                     Some(d) => f.advance_to(d.saturating_add(1)),
@@ -729,7 +754,13 @@ mod tests {
         hits: Vec<Ranked>,
     }
 
-    fn run(m: &MemTable, schema: &CollectionSchema, q: &str, mode: MatchMode, limit: usize) -> Outcome {
+    fn run(
+        m: &MemTable,
+        schema: &CollectionSchema,
+        q: &str,
+        mode: MatchMode,
+        limit: usize,
+    ) -> Outcome {
         let deleted = RoaringBitmap::new();
         let ctx = SearchContext::new(schema, vec![m], &deleted);
         let match_mode = match mode {
@@ -861,7 +892,9 @@ mod tests {
 
         let top_ids = |o: &Outcome, k: usize| {
             let mut hits = o.hits.clone();
-            hits.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap().then(a.doc_id.cmp(&b.doc_id)));
+            hits.sort_by(|a, b| {
+                b.score.partial_cmp(&a.score).unwrap().then(a.doc_id.cmp(&b.doc_id))
+            });
             hits.truncate(k);
             hits.into_iter().map(|h| h.doc_id).collect::<Vec<_>>()
         };

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -289,11 +289,69 @@ sizing `merge_fan_in` on a memory-constrained deployment — smaller values
 trade a bigger memory ceiling for more frequent, cheaper merges — but it is
 not sustained.
 
-## What is not built yet
+## Score-bound pruning
 
-**Block-max WAND.** The executor scores every match. Early termination would
-let it skip documents that cannot reach the top-K, which is what broad queries
-on large corpora need.
+Two independent pruning mechanisms compose on every search: one that never
+changes what a query reports, and one that does.
+
+### Tail pruning (exact)
+
+Every matching document is visited and counted — `found`, `matched`, and
+facets are always exact under this mechanism alone. What gets skipped, for
+documents a cheap upper bound proves cannot reach the final page, is the
+*expensive part* of per-document scoring — proximity, the popularity read,
+best-field `combine()`. The bound is real BM25 (exact, already known once a
+document is resolved) plus the maximum possible value of the other four
+`combine()` signals, which are non-negative-weighted and `[0,1]`-normalized,
+so the sum is a sound ceiling. This mechanism alone was measured, before true
+WAND existed, at a modest win (5M docs, ~9%-broad query: p95 494 ms → 454 ms)
+precisely because it never reduces how many documents get visited in the
+first place — see below for what does.
+
+### True block-max WAND (postings-level, approximate)
+
+Classical block-max WAND skips documents entirely, jumping ahead in sorted
+posting lists using per-block score bounds — incompatible with the exact
+counts the mechanism above preserves. This is now built as a genuinely
+separate, composed layer: `.post`'s v3 format groups a term's postings into
+fixed 128-document blocks, each carrying its own max doc id, max term
+frequency, and byte offset, so a query can skip — or jump straight past — a
+whole block without decoding a single posting inside it. A lazy
+`PostingCursor` (`crates/tachyon-index/src/cursor.rs`, `segment/cursor.rs`)
+walks one block at a time; `tachyon-query/src/wand.rs` merges cursors across
+sources and candidate terms into one frontier per query token, then runs a
+document-at-a-time driver:
+
+- **Disjunctive (`match_mode=any`)**: classic WAND pivot selection — sum
+  live frontiers' current-block bounds in ascending doc-id order; the first
+  prefix whose bound clears the current top-K threshold names the pivot
+  document. When *no* prefix clears it — the case a naive "always pick a
+  pivot" design misses, and the one that matters most for a single-token
+  query, which has only one frontier to pivot against — every live frontier
+  skips its own hopeless block outright.
+- **Conjunctive (`match_mode=all`, the default)**: a genuine match needs
+  every token, so the bound is the *sum* of every frontier's current-block
+  bound, checked *before* searching for agreement. When it clears the
+  threshold, exact leapfrog intersection finds the next doc id every
+  frontier agrees on — leapfrog's own catch-up never skips a genuine match,
+  so it alone never causes approximation. When the bound doesn't clear, the
+  intersection search is skipped entirely, which is what makes the default
+  mode benefit from this too, not just `any`.
+
+Both drivers still hand every visited document through the exact tail
+pruning above. The only source of approximation is a document that's never
+visited at all because a block was skipped — signaled per response by
+`found_is_exact: false`. Facets inherit the same caveat automatically, since
+they count over the same visited set `found` does.
+
+Measured on the same 5M-document HTTP benchmark, broad query (`any` mode,
+~9% of the corpus): search p95 went from 454 ms (tail pruning alone) to
+**278 ms** — the O(matches) walk itself is now genuinely reduced, not just
+its tail. `match_mode=all`, the default, does even better here (p95 **252
+ms**) since leapfrog intersection narrows the candidate set before the
+bound check ever runs.
+
+## What is not built yet
 
 **Streaming merges.** A merge currently rebuilds its input through a scratch
 memtable rather than merging the already-encoded structures directly, which


### PR DESCRIPTION
Postings-level pruning (segment format v3, block-structured .post with skip metadata, lazy PostingCursor, document-at-a-time WAND merge in wand.rs) replaces the term-at-a-time accumulator, reducing the O(matches) postings walk itself for both match_mode=any and the default all. found and facet counts become an honest lower bound whenever a skip occurs, signaled per response by found_is_exact.

5M-doc benchmark: search p95 454ms -> 278ms (any) / 252ms (all, default), down from the prior tail-only pruning's 454ms. Also fixes a merge/doc-id collision bug (merge_locked could hand the active memtable an id a just-merged segment already claimed) that surfaced as silent search undercounting at scale.