### PR TITLE
Cut query latency 2-2.7x by killing per-document allocation and dispa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,12 @@ broader than real traffic, and deliberately so, because it is the expensive case
 
 | | 100k documents | 1M documents | 5M documents | Target |
 |---|---|---|---|---|
-| Search p95 | **4.1 ms** | 51.3 ms | 259.5 ms | < 30 ms |
-| Search p99 | **5.1 ms** | 52.8 ms | 266.8 ms | < 60 ms |
-| Autocomplete p95 | **0.22 ms** | 2.4 ms | 18.3 ms | < 5 ms |
-| Indexing | **221k docs/sec** | 135k docs/sec | 54k docs/sec | 10k docs/sec |
-| Memory (steady RSS) | 406 MiB | 999 MiB | 3.1 GiB | — |
-| Memory (peak RSS) | 406 MiB | 1.0 GiB | 4.1 GiB | — |
+| Search p95 | **3.6 ms** | 31.6 ms | 160.3 ms | < 30 ms |
+| Search p99 | **4.3 ms** | 34.3 ms | 171.5 ms | < 60 ms |
+| Autocomplete p95 | **0.35 ms** | 0.24 ms | 1.4 ms | < 5 ms |
+| Indexing | **182k docs/sec** | 140k docs/sec | 50k docs/sec | 10k docs/sec |
+| Memory (steady RSS) | 403 MiB | 968 MiB | 3.4 GiB | — |
+| Memory (peak RSS) | 403 MiB | 999 MiB | 5.2 GiB | — |
 
 Both measured right after indexing finishes, before any searches run. Steady
 is current RSS at that point — what's resident most of the time. Peak is
@@ -121,9 +121,11 @@ Reproduce:
 cargo run --release -p tachyon-bench -- --documents 1000000 --queries 2000
 ```
 
-Indexing throughput beats the target by more than an order of magnitude.
-Search meets the latency target at 100k documents and misses it at 1M and 5M
-**on this corpus**; see [Known limitations](#known-limitations).
+Indexing throughput beats the target by more than an order of magnitude, and
+autocomplete now clears its target at every scale measured. Search meets the
+latency target at 100k documents; at 1M it misses by a hair (31.6 ms vs. the
+30 ms target) and at 5M it still misses by a wide margin **on this corpus**;
+see [Known limitations](#known-limitations).
 
 ---
 

--- a/crates/tachyon-bench/src/corpus.rs
+++ b/crates/tachyon-bench/src/corpus.rs
@@ -118,6 +118,20 @@ pub const BRANDS: &[&str] = &[
 pub const CATEGORIES: &[&str] =
     &["peripherals", "audio", "power", "display", "accessories", "storage"];
 
+/// Distinct adjective/noun variants generated when `--vocab-scale` widens the
+/// vocabulary beyond the base word lists. `1` reproduces the original
+/// 15x15-word corpus exactly (every query matches a wide swath of the
+/// collection, deliberately, per the module doc); higher values multiply the
+/// term count by suffixing each base word with a bucket number, spreading
+/// matches thinner the way a real catalogue's long tail does.
+fn vocab_word(base: &str, rng: &mut Rng, scale: usize) -> String {
+    if scale <= 1 {
+        return base.to_string();
+    }
+    let bucket = rng.zipfish(scale);
+    format!("{base}{bucket}")
+}
+
 /// The benchmark schema: the PRD §7.1 example, widened enough to exercise
 /// filters, sorting, and facets at once.
 pub fn schema(name: &str) -> CollectionSchema {
@@ -135,10 +149,11 @@ pub fn schema(name: &str) -> CollectionSchema {
     )
 }
 
-/// Generate one document.
-pub fn document(rng: &mut Rng, id: usize) -> Value {
-    let adjective = ADJECTIVES[rng.zipfish(ADJECTIVES.len())];
-    let noun = NOUNS[rng.zipfish(NOUNS.len())];
+/// Generate one document. `vocab_scale` widens the term count as described on
+/// [`vocab_word`]; pass `1` to reproduce the original fixed vocabulary.
+pub fn document(rng: &mut Rng, id: usize, vocab_scale: usize) -> Value {
+    let adjective = vocab_word(ADJECTIVES[rng.zipfish(ADJECTIVES.len())], rng, vocab_scale);
+    let noun = vocab_word(NOUNS[rng.zipfish(NOUNS.len())], rng, vocab_scale);
     let material = rng.pick(MATERIALS);
     let qualifier = rng.pick(QUALIFIERS);
 
@@ -161,18 +176,19 @@ pub fn document(rng: &mut Rng, id: usize) -> Value {
 }
 
 /// Queries a benchmark should ask: single words, pairs, a phrase, a typo, and
-/// a prefix — the shapes real traffic actually contains.
-pub fn queries(rng: &mut Rng, count: usize) -> Vec<String> {
+/// a prefix — the shapes real traffic actually contains. `vocab_scale`
+/// matches [`document`]'s, so queries land on terms that actually occur.
+pub fn queries(rng: &mut Rng, count: usize, vocab_scale: usize) -> Vec<String> {
     (0..count)
         .map(|i| {
-            let adjective = ADJECTIVES[rng.zipfish(ADJECTIVES.len())];
-            let noun = NOUNS[rng.zipfish(NOUNS.len())];
+            let adjective = vocab_word(ADJECTIVES[rng.zipfish(ADJECTIVES.len())], rng, vocab_scale);
+            let noun = vocab_word(NOUNS[rng.zipfish(NOUNS.len())], rng, vocab_scale);
             match i % 5 {
-                0 => noun.to_string(),
+                0 => noun.clone(),
                 1 => format!("{adjective} {noun}"),
                 2 => format!("\"{adjective} {noun}\""),
                 // A transposed pair of characters, the commonest real typo.
-                3 => transpose(adjective),
+                3 => transpose(&adjective),
                 _ => adjective[..adjective.len().min(4)].to_string(),
             }
         })

--- a/crates/tachyon-bench/src/main.rs
+++ b/crates/tachyon-bench/src/main.rs
@@ -63,6 +63,47 @@ struct Args {
     /// `--documents` so several flushes happen during one run.
     #[arg(long, default_value_t = 5_000)]
     flush_scenario_max_memtable_docs: usize,
+
+    /// Multiplies the corpus's distinct term count by suffixing each base
+    /// word with a bucket in `0..vocab_scale`. `1` (the default) reproduces
+    /// the original ~64-term corpus, where one query word matches ~6% of the
+    /// collection — deliberately broad, the expensive case. Real catalogues
+    /// look much more like a higher scale: a query term matching a thin
+    /// slice of the corpus rather than a wide swath of it.
+    #[arg(long, default_value_t = 1)]
+    vocab_scale: usize,
+
+    /// Memtable document threshold for the main Indexing/Search sections
+    /// (independent of `--flush-scenario-max-memtable-docs`, which only
+    /// applies to `--flush-scenario`). Defaults to unbounded so the main
+    /// section keeps measuring the index rather than the flush policy, same
+    /// as always — but that also means it never touches `SegmentReader` at
+    /// all: every read comes from the one giant memtable, so anything that
+    /// only pays off for on-disk segments (column caching, block-structured
+    /// postings, the autocomplete fast count) is invisible in the default
+    /// run. Set this below `--documents` to measure the collection the way
+    /// it actually looks in steady state: mostly segments, not one memtable.
+    #[arg(long, default_value_t = usize::MAX)]
+    max_memtable_docs: usize,
+
+    /// Also run a sustained-concurrency scenario: this many threads, each
+    /// continuously issuing plain-query searches against one shared,
+    /// already-indexed collection for `--concurrency-duration-secs`,
+    /// reporting aggregate throughput and mean per-query processing time —
+    /// the same pair Typesense's own published benchmarks report ("N
+    /// concurrent queries per second, average processing time of Xms").
+    /// `Collection::search` takes only a read lock, so this needs no engine
+    /// change to be safe — `--flush-scenario` above already proves the same
+    /// `Arc<Collection>` + multi-thread pattern works. 0 (the default)
+    /// skips this: every section above runs single-threaded, which is the
+    /// quantity that number is NOT, so without this flag nothing in this
+    /// binary's output is directly comparable to it.
+    #[arg(long, default_value_t = 0)]
+    concurrency: usize,
+
+    /// How long `--concurrency` hammers the shared collection.
+    #[arg(long, default_value_t = 10)]
+    concurrency_duration_secs: u64,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -77,15 +118,36 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         SyncPolicy::Interval(Duration::from_millis(200))
     });
-    // The whole corpus stays in one memtable so this measures the index, not
-    // the flush policy.
-    let config = config.with_max_memtable_docs(usize::MAX);
+    // Unbounded by default: the whole corpus stays in one memtable so this
+    // measures the index, not the flush policy. Override with
+    // `--max-memtable-docs` to measure against on-disk segments instead.
+    let config = config.with_max_memtable_docs(args.max_memtable_docs);
 
     println!("Tachyon benchmark");
     println!("  documents   {}", args.documents);
     println!("  queries     {}", args.queries);
     println!("  batch size  {}", args.batch_size);
     println!("  fsync       {}", if args.fsync { "every batch" } else { "every 200ms" });
+    println!(
+        "  vocab scale {}  ({})",
+        args.vocab_scale,
+        if args.vocab_scale <= 1 {
+            "fixed ~64-term corpus, deliberately broad matches"
+        } else {
+            "widened vocabulary, thinner matches per term"
+        }
+    );
+    println!(
+        "  max memtable docs  {}",
+        if args.max_memtable_docs == usize::MAX {
+            // Still subject to `max_memtable_bytes` (default 256 MiB), so a
+            // large `--documents` flushes into segments anyway — this only
+            // disables the doc-count trigger, not flushing altogether.
+            "unbounded by doc count (256 MiB byte threshold still applies)".to_string()
+        } else {
+            args.max_memtable_docs.to_string()
+        }
+    );
     println!();
 
     let collection = Collection::create(&layout, corpus::schema("products"), &config)?;
@@ -97,8 +159,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     while indexed < args.documents {
         let this_batch = args.batch_size.min(args.documents - indexed);
-        let batch: Vec<_> =
-            (0..this_batch).map(|i| corpus::document(&mut rng, indexed + i)).collect();
+        let batch: Vec<_> = (0..this_batch)
+            .map(|i| corpus::document(&mut rng, indexed + i, args.vocab_scale))
+            .collect();
         let report = collection.upsert_batch(batch)?;
         if report.num_failed > 0 {
             return Err(format!("{} documents failed to index", report.num_failed).into());
@@ -116,6 +179,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         args.documents as f64 / index_elapsed.as_secs_f64()
     );
     println!("  documents      {}", stats.num_documents);
+    println!("  segments       {}", stats.num_segments);
     println!("  memtable       {}", human_bytes(stats.memtable_bytes));
     println!("  wal            {}", human_bytes(stats.wal_bytes as usize));
     println!("  bytes/doc      {}", human_bytes(stats.memtable_bytes / args.documents.max(1)));
@@ -127,7 +191,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // --- Search -----------------------------------------------------------
     let mut rng = Rng::new(args.seed ^ 0x5eed);
-    let queries = corpus::queries(&mut rng, args.queries);
+    let queries = corpus::queries(&mut rng, args.queries, args.vocab_scale);
 
     let plain = measure(&collection, &queries, |q| SearchParams {
         q: Some(q.to_string()),
@@ -179,6 +243,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         run_flush_scenario(&args)?;
     }
 
+    if args.concurrency > 0 {
+        run_concurrency_scenario(&args)?;
+    }
+
     Ok(())
 }
 
@@ -203,7 +271,7 @@ fn run_flush_scenario(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
     let collection = Arc::new(Collection::create(&layout, corpus::schema("products"), &config)?);
 
     let mut rng = Rng::new(args.seed ^ 0x5eed);
-    let queries = corpus::queries(&mut rng, args.queries.max(200));
+    let queries = corpus::queries(&mut rng, args.queries.max(200), args.vocab_scale);
 
     let stop = Arc::new(AtomicBool::new(false));
     let latencies = Arc::new(Mutex::new(Vec::<u64>::new()));
@@ -239,8 +307,9 @@ fn run_flush_scenario(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
     let mut indexed = 0usize;
     while indexed < args.documents {
         let this_batch = args.batch_size.min(args.documents - indexed);
-        let batch: Vec<_> =
-            (0..this_batch).map(|i| corpus::document(&mut rng, indexed + i)).collect();
+        let batch: Vec<_> = (0..this_batch)
+            .map(|i| corpus::document(&mut rng, indexed + i, args.vocab_scale))
+            .collect();
         let report = collection.upsert_batch(batch)?;
         if report.num_failed > 0 {
             return Err(format!("{} documents failed to index", report.num_failed).into());
@@ -268,6 +337,109 @@ fn run_flush_scenario(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
     let total_hits = total_hits.load(Ordering::Relaxed);
     let measurement = Measurement { latencies, total_hits };
     report("Search, concurrent with flushing", &measurement, 60.0);
+
+    Ok(())
+}
+
+/// Index a fresh collection, then hammer it with `--concurrency` threads
+/// each running the plain-query workload continuously for
+/// `--concurrency-duration-secs`, and report aggregate throughput and mean
+/// per-query processing time — the pair Typesense's own benchmarks publish.
+/// `Collection::search` takes only a read lock (see its doc comment), so
+/// many threads calling it concurrently is an already-supported, already-
+/// exercised pattern (`run_flush_scenario` above does the same
+/// `Arc<Collection>` + `thread::spawn` shape); this needed no engine change.
+fn run_concurrency_scenario(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
+    println!("Concurrency scenario");
+    println!("  threads                 {}", args.concurrency);
+    println!("  duration                {}s", args.concurrency_duration_secs);
+    println!();
+
+    let dir = tempfile::tempdir()?;
+    let layout = Layout::new(dir.path());
+    layout.initialize()?;
+    let config = EngineConfig::new(dir.path())
+        .with_sync_policy(SyncPolicy::Interval(Duration::from_millis(200)))
+        .with_max_memtable_docs(args.max_memtable_docs);
+
+    let collection = Arc::new(Collection::create(&layout, corpus::schema("products"), &config)?);
+
+    let mut rng = Rng::new(args.seed);
+    let mut indexed = 0usize;
+    while indexed < args.documents {
+        let this_batch = args.batch_size.min(args.documents - indexed);
+        let batch: Vec<_> = (0..this_batch)
+            .map(|i| corpus::document(&mut rng, indexed + i, args.vocab_scale))
+            .collect();
+        let report = collection.upsert_batch(batch)?;
+        if report.num_failed > 0 {
+            return Err(format!("{} documents failed to index", report.num_failed).into());
+        }
+        indexed += this_batch;
+    }
+    collection.sync()?;
+
+    let mut rng = Rng::new(args.seed ^ 0x5eed);
+    let queries = Arc::new(corpus::queries(&mut rng, args.queries.max(200), args.vocab_scale));
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let total_queries = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let errors = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let latencies: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let started = Instant::now();
+    let mut handles = Vec::with_capacity(args.concurrency);
+    for _ in 0..args.concurrency {
+        let collection = Arc::clone(&collection);
+        let queries = Arc::clone(&queries);
+        let stop = Arc::clone(&stop);
+        let total_queries = Arc::clone(&total_queries);
+        let errors = Arc::clone(&errors);
+        let latencies = Arc::clone(&latencies);
+        handles.push(std::thread::spawn(move || {
+            let mut i = 0usize;
+            let mut local_latencies = Vec::new();
+            while !stop.load(Ordering::Relaxed) {
+                let q = &queries[i % queries.len()];
+                let query_started = Instant::now();
+                match collection.search(SearchParams { q: Some(q.clone()), ..Default::default() }) {
+                    Ok(_) => local_latencies.push(query_started.elapsed().as_micros() as u64),
+                    Err(_) => {
+                        errors.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+                i += 1;
+            }
+            total_queries.fetch_add(local_latencies.len() as u64, Ordering::Relaxed);
+            latencies.lock().expect("latencies mutex poisoned").extend(local_latencies);
+        }));
+    }
+
+    std::thread::sleep(Duration::from_secs(args.concurrency_duration_secs));
+    stop.store(true, Ordering::Relaxed);
+    for h in handles {
+        h.join().expect("worker thread panicked");
+    }
+    let elapsed = started.elapsed();
+
+    let total = total_queries.load(Ordering::Relaxed);
+    let errors = errors.load(Ordering::Relaxed);
+    let qps = total as f64 / elapsed.as_secs_f64();
+    let latencies =
+        Arc::try_unwrap(latencies).expect("every worker thread has joined").into_inner().unwrap();
+    let mean_ms = latencies.iter().sum::<u64>() as f64 / latencies.len().max(1) as f64 / 1000.0;
+
+    println!("  queries completed       {total}");
+    if errors > 0 {
+        println!("  errors                  {errors}  (excluded from latency stats)");
+    }
+    println!("  elapsed                 {:.2}s", elapsed.as_secs_f64());
+    println!(
+        "  throughput              {qps:.1} concurrent queries/sec  \
+         (Typesense reference: 104 @ 4 vCPU / 2.2M docs)"
+    );
+    println!("  mean processing time    {mean_ms:.2} ms  (Typesense reference: 11 ms)");
+    println!();
 
     Ok(())
 }
@@ -312,6 +484,13 @@ fn report(label: &str, measurement: &Measurement, target_p95_ms: f64) {
 
     let p95 = percentile(0.95);
     let mean = sorted.iter().sum::<u64>() as f64 / sorted.len().max(1) as f64 / 1000.0;
+    let mean_hits = measurement.total_hits as f64 / sorted.len().max(1) as f64;
+    // The cost-per-matched-document ratio: latency should be dominated by work
+    // proportional to how many documents a query actually touches, not by
+    // corpus size on its own. Comparing this figure across corpus sizes is
+    // what tells apart "the walk got more expensive" from "the query just
+    // matched more documents" — the two look identical in raw latency alone.
+    let ns_per_hit = if mean_hits > 0.0 { mean * 1_000_000.0 / mean_hits } else { 0.0 };
 
     println!("{label}");
     println!("  queries        {}", sorted.len());
@@ -323,7 +502,8 @@ fn report(label: &str, measurement: &Measurement, target_p95_ms: f64) {
     );
     println!("  p99            {:.2} ms", percentile(0.99));
     println!("  max            {:.2} ms", percentile(1.0));
-    println!("  mean hits      {:.0}", measurement.total_hits as f64 / sorted.len().max(1) as f64);
+    println!("  mean hits      {mean_hits:.0}");
+    println!("  ns/matched doc {ns_per_hit:.0}");
     println!();
 }
 
@@ -336,7 +516,11 @@ fn peak_rss_bytes() -> usize {
         usage.ru_maxrss
     };
     // Linux reports ru_maxrss in KiB; Darwin reports it in bytes.
-    if cfg!(target_os = "linux") { maxrss as usize * 1024 } else { maxrss as usize }
+    if cfg!(target_os = "linux") {
+        maxrss as usize * 1024
+    } else {
+        maxrss as usize
+    }
 }
 
 /// Current resident set size, via `ps` — unlike `peak_rss_bytes`, this can

--- a/crates/tachyon-index/src/cursor.rs
+++ b/crates/tachyon-index/src/cursor.rs
@@ -30,6 +30,17 @@ pub trait PostingCursor {
     /// bound proves unnecessary to visit never pays this cost.
     fn positions(&self) -> Vec<u32>;
 
+    /// Append the current doc id's positions into `out`, without an
+    /// intermediate allocation. Same data as [`PostingCursor::positions`];
+    /// override this when the underlying storage can write directly into
+    /// `out` instead of allocating and handing back a fresh `Vec` — a broad
+    /// query resolves this once per (matched document, matched token), so
+    /// the allocation `positions()` pays for its return value is real cost
+    /// at scale.
+    fn positions_into(&self, out: &mut Vec<u32>) {
+        out.extend_from_slice(&self.positions());
+    }
+
     /// Move to the next doc id.
     fn advance(&mut self) -> Option<DocId>;
 
@@ -75,6 +86,12 @@ impl PostingCursor for MemTablePostingCursor<'_> {
 
     fn positions(&self) -> Vec<u32> {
         self.docs.get(self.pos).map_or_else(Vec::new, |d| d.positions.clone())
+    }
+
+    fn positions_into(&self, out: &mut Vec<u32>) {
+        if let Some(d) = self.docs.get(self.pos) {
+            out.extend_from_slice(&d.positions);
+        }
     }
 
     fn advance(&mut self) -> Option<DocId> {
@@ -143,6 +160,12 @@ impl PostingCursor for MergeCursor<'_> {
 
     fn positions(&self) -> Vec<u32> {
         self.current.map_or_else(Vec::new, |i| self.children[i].positions())
+    }
+
+    fn positions_into(&self, out: &mut Vec<u32>) {
+        if let Some(i) = self.current {
+            self.children[i].positions_into(out);
+        }
     }
 
     fn advance(&mut self) -> Option<DocId> {

--- a/crates/tachyon-index/src/segment/codec.rs
+++ b/crates/tachyon-index/src/segment/codec.rs
@@ -400,14 +400,29 @@ pub(crate) fn decode_block_skeleton(bytes: &[u8], meta: &BlockMeta) -> Result<Bl
 /// One document's positions, decoded on demand from an offset
 /// [`decode_block_skeleton`] already located.
 pub(crate) fn decode_positions_at(bytes: &[u8], offset: u64, tf: u32) -> Result<Vec<u32>> {
+    let mut positions = Vec::with_capacity(tf as usize);
+    decode_positions_into(bytes, offset, tf, &mut positions)?;
+    Ok(positions)
+}
+
+/// Same decode as [`decode_positions_at`], appending into a caller-owned,
+/// reused buffer instead of allocating a fresh `Vec` per call — the shape a
+/// hot query-time caller wants, since a broad query decodes positions for
+/// many (document, token) pairs per search.
+pub(crate) fn decode_positions_into(
+    bytes: &[u8],
+    offset: u64,
+    tf: u32,
+    out: &mut Vec<u32>,
+) -> Result<()> {
     let what = POST_BLOCK_WHAT;
     let slice = bytes_at(bytes, offset as usize, tf as usize * 4, what)?;
     let mut cur = Cursor::new(slice, what);
-    let mut positions = Vec::with_capacity(tf as usize);
+    out.reserve(tf as usize);
     for _ in 0..tf {
-        positions.push(cur.read_u32()?);
+        out.push(cur.read_u32()?);
     }
-    Ok(positions)
+    Ok(())
 }
 
 /// Just the document ids one term occurs in, for one field — no positions

--- a/crates/tachyon-index/src/segment/cursor.rs
+++ b/crates/tachyon-index/src/segment/cursor.rs
@@ -78,6 +78,18 @@ impl PostingCursor for SegmentPostingCursor<'_> {
         })
     }
 
+    fn positions_into(&self, out: &mut Vec<u32>) {
+        let Some(skeleton) = &self.skeleton else { return };
+        let (Some(&offset), Some(&tf)) =
+            (skeleton.positions_offsets.get(self.doc_idx), skeleton.tfs.get(self.doc_idx))
+        else {
+            return;
+        };
+        if let Err(e) = codec::decode_positions_into(self.bytes, offset, tf, out) {
+            tracing::warn!(error = %e, "segment: failed to decode posting positions");
+        }
+    }
+
     fn advance(&mut self) -> Option<DocId> {
         let len = self.skeleton.as_ref().map_or(0, |s| s.doc_ids.len());
         if self.doc_idx + 1 < len {

--- a/crates/tachyon-index/src/segment/reader.rs
+++ b/crates/tachyon-index/src/segment/reader.rs
@@ -13,6 +13,7 @@ use std::borrow::Cow;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use memmap2::{Mmap, MmapOptions};
 use roaring::RoaringBitmap;
@@ -47,6 +48,19 @@ pub struct SegmentReader {
     col_header: ColHeader,
     doc: Mmap,
     doc_header: DocHeader,
+    /// One slot per field, filled in on first access and never rebuilt after
+    /// — a segment's columns never change once written, so decoding a
+    /// numeric column (every `(value, doc_id)` pair, resorted into a
+    /// `NumericColumn`) or a keyword column (every distinct value's
+    /// `RoaringBitmap`, deserialized) is real work worth doing at most once
+    /// per field per segment lifetime rather than once per query. Filters
+    /// and facets both go through these, and a query with either used to pay
+    /// this decode cost fresh on every call, which is why filtering used to
+    /// make a query *slower* than the unfiltered version despite touching
+    /// fewer documents. `OnceLock` rather than a `Mutex`: reads from many
+    /// concurrent searches never block each other once the slot is filled.
+    numeric_cache: Vec<OnceLock<Option<NumericColumn>>>,
+    keyword_cache: Vec<OnceLock<Option<KeywordColumn>>>,
 }
 
 /// Map a whole file. Used for `.post`/`.col`/`.doc`, whose own headers (read
@@ -103,7 +117,22 @@ impl SegmentReader {
             )));
         }
 
-        Ok(SegmentReader { terms, ids, post, post_header, col, col_header, doc, doc_header })
+        let num_fields = schema.fields.len();
+        let numeric_cache = std::iter::repeat_with(OnceLock::new).take(num_fields).collect();
+        let keyword_cache = std::iter::repeat_with(OnceLock::new).take(num_fields).collect();
+
+        Ok(SegmentReader {
+            terms,
+            ids,
+            post,
+            post_header,
+            col,
+            col_header,
+            doc,
+            doc_header,
+            numeric_cache,
+            keyword_cache,
+        })
     }
 
     /// Segment-local id resolution, mirroring `MemTable::lookup`. Not part of
@@ -157,23 +186,31 @@ impl IndexSource for SegmentReader {
     }
 
     fn numeric_column(&self, field: FieldId) -> Option<Cow<'_, NumericColumn>> {
-        match codec::decode_numeric_column(&self.col, &self.col_header, field) {
-            Ok(col) => col.map(Cow::Owned),
-            Err(e) => {
-                tracing::warn!(field, error = %e, "segment: failed to decode numeric column");
-                None
+        let slot = self.numeric_cache.get(field as usize)?;
+        let cached = slot.get_or_init(|| {
+            match codec::decode_numeric_column(&self.col, &self.col_header, field) {
+                Ok(col) => col,
+                Err(e) => {
+                    tracing::warn!(field, error = %e, "segment: failed to decode numeric column");
+                    None
+                }
             }
-        }
+        });
+        cached.as_ref().map(Cow::Borrowed)
     }
 
     fn keyword_column(&self, field: FieldId) -> Option<Cow<'_, KeywordColumn>> {
-        match codec::decode_keyword_column(&self.col, &self.col_header, field) {
-            Ok(col) => col.map(Cow::Owned),
-            Err(e) => {
-                tracing::warn!(field, error = %e, "segment: failed to decode keyword column");
-                None
+        let slot = self.keyword_cache.get(field as usize)?;
+        let cached = slot.get_or_init(|| {
+            match codec::decode_keyword_column(&self.col, &self.col_header, field) {
+                Ok(col) => col,
+                Err(e) => {
+                    tracing::warn!(field, error = %e, "segment: failed to decode keyword column");
+                    None
+                }
             }
-        }
+        });
+        cached.as_ref().map(Cow::Borrowed)
     }
 
     fn posting_cursor(&self, term: &str, field: FieldId) -> Option<Box<dyn PostingCursor + '_>> {
@@ -210,6 +247,25 @@ impl IndexSource for SegmentReader {
     }
 
     fn live_doc_freq(&self, term: &str, field: FieldId, deleted: &RoaringBitmap) -> u64 {
+        // Fast path: if nothing in this segment's own doc id range has been
+        // deleted since it was flushed — no internal holes, and no
+        // collection-wide tombstone falls inside its range either — every
+        // posting the stored `doc_freq` counts is genuinely live, so the
+        // count can be read directly instead of decoded and filtered.
+        // Autocomplete calls this for dozens of candidate terms per
+        // keystroke, across every field and every segment, so turning the
+        // common case (a collection with few or no deletes) from O(doc_freq)
+        // into O(1) matters even though it changes no result.
+        let no_holes =
+            self.doc_header.presence.len() == (self.doc_header.end - self.doc_header.base) as u64;
+        let untouched_by_tombstones = match (deleted.min(), deleted.max()) {
+            (Some(lo), Some(hi)) => hi < self.doc_header.base || lo >= self.doc_header.end,
+            _ => true,
+        };
+        if no_holes && untouched_by_tombstones {
+            return self.doc_freq(term, field) as u64;
+        }
+
         let Some(term_id) = self.terms.get(term) else { return 0 };
         match codec::decode_term_field_doc_ids(&self.post, &self.post_header, term_id, field) {
             Ok(doc_ids) => doc_ids
@@ -438,6 +494,40 @@ mod tests {
         assert_eq!(brand.equals("Logitech").iter().collect::<Vec<_>>(), vec![0]);
         let price = seg.numeric_column(3).unwrap();
         assert_eq!(price.range(Some(NumKey::Int(1999)), Some(NumKey::Int(2999))).len(), 2);
+    }
+
+    #[test]
+    fn live_doc_freq_fast_path_agrees_with_the_slow_path() {
+        // A segment with no holes at all (nothing was deleted before this
+        // flush), so `live_doc_freq`'s O(1) stored-count fast path applies —
+        // verify it agrees with what the full decode-and-filter walk would
+        // produce, and that a tombstone landing outside vs. inside this
+        // segment's own doc id range correctly selects the fast path only
+        // when it's actually safe to.
+        let schema = schema();
+        let mut m = MemTable::new(0, &schema);
+        m.insert(doc("1", "wireless mouse", &["red", "blue"], "Logitech", 2999));
+        m.insert(doc("2", "mouse pad", &["blue"], "Razer", 1999));
+        let dir = tempfile::tempdir().unwrap();
+        let encoded = super::super::encode(&m, &schema).unwrap();
+        let paths = write_segment(dir.path(), &encoded);
+        let reader = SegmentReader::open(&paths, &schema).unwrap();
+
+        // Fast path: no tombstones at all.
+        assert_eq!(reader.live_doc_freq("mouse", 0, &RoaringBitmap::new()), 2);
+
+        // Fast path: a tombstone exists, but outside this segment's own doc
+        // id range — must not affect the count.
+        let far_tombstone = RoaringBitmap::from_iter([1000u32]);
+        assert_eq!(reader.live_doc_freq("mouse", 0, &far_tombstone), 2);
+
+        // Fallback: a tombstone lands inside the segment's range — the fast
+        // path's preconditions no longer hold, so this must take the
+        // decode-and-filter path and still produce the reduced, correct
+        // count.
+        let doc0 = reader.lookup_id("1").unwrap();
+        let near_tombstone = RoaringBitmap::from_iter([doc0]);
+        assert_eq!(reader.live_doc_freq("mouse", 0, &near_tombstone), 1);
     }
 
     #[test]

--- a/crates/tachyon-query/src/executor.rs
+++ b/crates/tachyon-query/src/executor.rs
@@ -31,6 +31,7 @@
 //! same match rather than a blend of unrelated ones.
 
 use std::borrow::Cow;
+use std::cell::Cell;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
@@ -59,6 +60,16 @@ pub struct SearchContext<'a> {
     pub sources: Vec<&'a dyn IndexSource>,
     /// Collection-wide tombstones, covering documents inside segments.
     pub deleted: &'a RoaringBitmap,
+    /// Index into `sources` that most recently answered a `value`/
+    /// `field_len`/`is_live` lookup. Both WAND drivers visit doc ids in
+    /// strictly ascending order and a source owns a contiguous, disjoint
+    /// range, so consecutive lookups overwhelmingly land on the same source
+    /// many documents in a row; checking it first turns that common case
+    /// into one dyn-dispatched range check instead of scanning every source
+    /// from the top. A miss always falls through to the full scan below, so
+    /// this can only change how fast the common case resolves, never which
+    /// source ends up answering a lookup.
+    source_hint: Cell<usize>,
 }
 
 impl<'a> SearchContext<'a> {
@@ -67,7 +78,7 @@ impl<'a> SearchContext<'a> {
         sources: Vec<&'a dyn IndexSource>,
         deleted: &'a RoaringBitmap,
     ) -> Self {
-        SearchContext { schema, sources, deleted }
+        SearchContext { schema, sources, deleted, source_hint: Cell::new(0) }
     }
 
     /// Corpus statistics for a field, summed across every source. BM25 needs
@@ -92,19 +103,42 @@ impl<'a> SearchContext<'a> {
     /// whenever one turns out not to actually hold `doc_id` live, rather
     /// than trusting the first (possibly hole-only) match.
     pub(crate) fn value(&self, doc_id: DocId, field: FieldId) -> Option<Cow<'a, Value>> {
-        self.sources.iter().find_map(|s| {
-            (doc_id >= s.min_doc_id() && doc_id < s.end_doc_id()).then(|| s.value(doc_id, field))?
-        })
+        let hint = self.source_hint.get();
+        if let Some(s) = self.sources.get(hint) {
+            if doc_id >= s.min_doc_id() && doc_id < s.end_doc_id() {
+                if let Some(v) = s.value(doc_id, field) {
+                    return Some(v);
+                }
+            }
+        }
+        for (i, s) in self.sources.iter().enumerate() {
+            if doc_id >= s.min_doc_id() && doc_id < s.end_doc_id() {
+                if let Some(v) = s.value(doc_id, field) {
+                    self.source_hint.set(i);
+                    return Some(v);
+                }
+            }
+        }
+        None
     }
 
     /// The owning source's own `field_len`, or `0` if no source actually
     /// holds this doc id live. See `Self::value`'s doc comment for why a
     /// range match alone isn't enough to stop the search.
     pub(crate) fn field_len(&self, doc_id: DocId, field: FieldId) -> u32 {
-        self.sources
-            .iter()
-            .find(|s| doc_id >= s.min_doc_id() && doc_id < s.end_doc_id() && s.is_live(doc_id))
-            .map_or(0, |s| s.field_len(doc_id, field))
+        let hint = self.source_hint.get();
+        if let Some(s) = self.sources.get(hint) {
+            if doc_id >= s.min_doc_id() && doc_id < s.end_doc_id() && s.is_live(doc_id) {
+                return s.field_len(doc_id, field);
+            }
+        }
+        for (i, s) in self.sources.iter().enumerate() {
+            if doc_id >= s.min_doc_id() && doc_id < s.end_doc_id() && s.is_live(doc_id) {
+                self.source_hint.set(i);
+                return s.field_len(doc_id, field);
+            }
+        }
+        0
     }
 
     /// Whether `doc_id` is live in whichever source actually holds it, and
@@ -113,10 +147,22 @@ impl<'a> SearchContext<'a> {
     /// here it runs once per document actually reached by a driver. See
     /// `Self::value`'s doc comment for why a range match alone isn't enough.
     pub(crate) fn is_live(&self, doc_id: DocId) -> bool {
-        self.sources
-            .iter()
-            .any(|s| doc_id >= s.min_doc_id() && doc_id < s.end_doc_id() && s.is_live(doc_id))
-            && !self.deleted.contains(doc_id)
+        if self.deleted.contains(doc_id) {
+            return false;
+        }
+        let hint = self.source_hint.get();
+        if let Some(s) = self.sources.get(hint) {
+            if doc_id >= s.min_doc_id() && doc_id < s.end_doc_id() && s.is_live(doc_id) {
+                return true;
+            }
+        }
+        for (i, s) in self.sources.iter().enumerate() {
+            if doc_id >= s.min_doc_id() && doc_id < s.end_doc_id() && s.is_live(doc_id) {
+                self.source_hint.set(i);
+                return true;
+            }
+        }
+        false
     }
 }
 
@@ -208,14 +254,27 @@ pub fn execute(ctx: &SearchContext, req: &SearchRequest) -> SearchOutcome {
         wand::DocScorer::new(ctx, req, filter, allowed_edits, needs_positions, tokens.len());
     let mut top_k = prunable.then(|| TopKByScore::new(req.window()));
     let mut candidates: Vec<Ranked> = Vec::new(); // used only when `top_k` is None
+                                                  // One scratch buffer, reused for every document either driver visits —
+                                                  // see `wand::DocEvidence`'s doc comment for why this matters.
+    let mut evidence = wand::DocEvidence::new(req.query_by.len(), tokens.len());
 
     let (matched_ids, any_skip) = match req.match_mode {
-        MatchMode::Any => {
-            wand::run_disjunctive(&mut frontiers, &query, &scorer, &mut top_k, &mut candidates)
-        }
-        MatchMode::All => {
-            wand::run_conjunctive(&mut frontiers, &query, &scorer, &mut top_k, &mut candidates)
-        }
+        MatchMode::Any => wand::run_disjunctive(
+            &mut frontiers,
+            &query,
+            &scorer,
+            &mut evidence,
+            &mut top_k,
+            &mut candidates,
+        ),
+        MatchMode::All => wand::run_conjunctive(
+            &mut frontiers,
+            &query,
+            &scorer,
+            &mut evidence,
+            &mut top_k,
+            &mut candidates,
+        ),
     };
 
     // Both drivers visit doc ids in strictly ascending order (`MergeCursor`

--- a/crates/tachyon-query/src/wand.rs
+++ b/crates/tachyon-query/src/wand.rs
@@ -97,19 +97,20 @@ impl FieldCandidates<'_> {
         min
     }
 
-    /// This token's resolved match in this field at `doc_id`, or `None` if
-    /// no candidate is present there. See this module's doc comment for the
-    /// exact multi-candidate aggregation rule this implements.
-    fn resolve(
+    /// This token's BM25 contribution and edit distance in this field at
+    /// `doc_id`, written into `slot` — never touches positions, so this is
+    /// cheap enough to run for every visited document regardless of whether
+    /// it ends up scored. See this module's doc comment for the exact
+    /// multi-candidate aggregation rule this implements.
+    fn resolve_contribution_into(
         &self,
         doc_id: DocId,
         field_len: u32,
         stats: FieldStats,
-        needs_positions: bool,
-    ) -> Option<FieldMatch> {
+        slot: &mut MatchSlot,
+    ) {
         let mut best_contribution = 0.0f32;
         let mut best_edits = u32::MAX;
-        let mut positions = Vec::new();
         let mut matched = false;
 
         for c in &self.candidates {
@@ -124,16 +125,24 @@ impl FieldCandidates<'_> {
             if c.edits < best_edits {
                 best_edits = c.edits;
             }
-            if needs_positions {
-                positions.extend(c.cursor.positions());
-            }
         }
 
-        matched.then_some(FieldMatch {
-            contribution: best_contribution,
-            edits: best_edits,
-            positions,
-        })
+        slot.matched = matched;
+        slot.contribution = best_contribution;
+        slot.edits = best_edits;
+    }
+
+    /// This token's positions in this field at `doc_id`, appended into
+    /// `out` — the union across every matching candidate, same rule as
+    /// [`Self::resolve_contribution_into`]. Called only for documents that
+    /// actually need scoring (or phrase verification), never for one a bound
+    /// already proved isn't worth the decode.
+    fn positions_into(&self, doc_id: DocId, out: &mut Vec<u32>) {
+        for c in &self.candidates {
+            if c.cursor.doc_id() == Some(doc_id) {
+                c.cursor.positions_into(out);
+            }
+        }
     }
 }
 
@@ -141,11 +150,24 @@ impl FieldCandidates<'_> {
 /// the pruning driver operates on, one per token.
 pub(crate) struct TokenFrontier<'a> {
     fields: Vec<FieldCandidates<'a>>,
+    /// Cached result of the multi-field, multi-candidate `min` walk below,
+    /// kept in sync by [`Self::recompute`] on every `advance`/`advance_to`
+    /// rather than recomputed on read. Both drivers read a frontier's
+    /// current doc id several times per document visited (building the
+    /// pivot list, sorting it, checking the pivot, advancing matched
+    /// cursors) without the frontier moving in between, so caching turns
+    /// most of those into a field read instead of a fan-out over `dyn
+    /// PostingCursor`s several layers deep.
+    current: Option<DocId>,
 }
 
 impl TokenFrontier<'_> {
     fn doc_id(&self) -> Option<DocId> {
-        self.fields.iter().filter_map(FieldCandidates::doc_id).min()
+        self.current
+    }
+
+    fn recompute(&mut self) {
+        self.current = self.fields.iter().filter_map(FieldCandidates::doc_id).min();
     }
 
     /// Max-over-fields of each field's bound: only one field ultimately
@@ -176,7 +198,7 @@ impl TokenFrontier<'_> {
     /// Advance every candidate, in every field, currently sitting at this
     /// frontier's own current (smallest) doc id.
     fn advance(&mut self) {
-        let Some(current) = self.doc_id() else { return };
+        let Some(current) = self.current else { return };
         for f in &mut self.fields {
             for c in &mut f.candidates {
                 if c.cursor.doc_id() == Some(current) {
@@ -184,6 +206,7 @@ impl TokenFrontier<'_> {
                 }
             }
         }
+        self.recompute();
     }
 
     fn advance_to(&mut self, target: DocId) {
@@ -194,6 +217,7 @@ impl TokenFrontier<'_> {
                 }
             }
         }
+        self.recompute();
     }
 }
 
@@ -240,8 +264,9 @@ pub(crate) fn build_frontiers<'a>(
                     }
                     FieldCandidates { candidates: field_candidates }
                 })
-                .collect();
-            TokenFrontier { fields }
+                .collect::<Vec<FieldCandidates<'a>>>();
+            let current = fields.iter().filter_map(FieldCandidates::doc_id).min();
+            TokenFrontier { fields, current }
         })
         .collect()
 }
@@ -263,10 +288,15 @@ fn bound_to_combined_score(bm25_bound: f32, scorer: &DocScorer) -> f32 {
     .combine(&scorer.weights)
 }
 
-/// One matched (token, field) cell: the winning candidate's contribution and
-/// edit distance, and the union of every matching candidate's positions —
-/// see this module's doc comment for the exact aggregation rule.
-struct FieldMatch {
+/// One (token, field) cell's evidence: the winning candidate's contribution
+/// and edit distance, and the union of every matching candidate's
+/// positions — see this module's doc comment for the exact aggregation rule.
+/// `positions` keeps its heap allocation across documents (cleared, not
+/// dropped, by [`DocEvidence::reset`]) since a broad query resolves this slot
+/// for hundreds of thousands of documents in one search.
+#[derive(Default)]
+struct MatchSlot {
+    matched: bool,
     contribution: f32,
     edits: u32,
     positions: Vec<u32>,
@@ -276,32 +306,74 @@ struct FieldMatch {
 /// that doc id. Mirrors the retired `Accumulator`'s per-slot API, but for a
 /// single document — the pruning walk visits one document at a time rather
 /// than building a flat table across every match up front.
-struct DocEvidence {
-    /// `[field_pos][token_idx]`.
-    matches: Vec<Vec<Option<FieldMatch>>>,
+///
+/// Owned once per query and reused across every document a driver visits
+/// ([`DocScorer::resolve_contributions`] calls [`DocEvidence::reset`] at the
+/// start of each document) rather than allocated fresh per document: a broad
+/// query can visit hundreds of thousands of documents, and a fresh
+/// `Vec`-of-`Vec`s per document was the largest source of allocator traffic
+/// in the whole query path.
+pub(crate) struct DocEvidence {
+    num_tokens: usize,
+    /// `[field_pos * num_tokens + token_idx]`.
+    slots: Vec<MatchSlot>,
 }
 
 impl DocEvidence {
+    pub(crate) fn new(num_fields: usize, num_tokens: usize) -> DocEvidence {
+        let mut slots = Vec::with_capacity(num_fields * num_tokens);
+        slots.resize_with(num_fields * num_tokens, MatchSlot::default);
+        DocEvidence { num_tokens, slots }
+    }
+
+    fn slot(&self, field: usize, token: usize) -> &MatchSlot {
+        &self.slots[field * self.num_tokens + token]
+    }
+
+    fn slot_mut(&mut self, field: usize, token: usize) -> &mut MatchSlot {
+        &mut self.slots[field * self.num_tokens + token]
+    }
+
+    /// Clear every slot for a new document, keeping each `positions` `Vec`'s
+    /// heap allocation rather than dropping it.
+    fn reset(&mut self) {
+        for slot in &mut self.slots {
+            slot.matched = false;
+            slot.contribution = 0.0;
+            slot.edits = 0;
+            slot.positions.clear();
+        }
+    }
+
     fn matched(&self, field: usize, token: usize) -> bool {
-        self.matches[field][token].is_some()
+        self.slot(field, token).matched
     }
 
     fn field_bm25(&self, field: usize) -> f32 {
-        self.matches[field].iter().filter_map(|m| m.as_ref()).map(|m| m.contribution).sum()
+        (0..self.num_tokens)
+            .map(|t| self.slot(field, t))
+            .filter(|s| s.matched)
+            .map(|s| s.contribution)
+            .sum()
     }
 
     fn field_edits(&self, field: usize) -> u32 {
-        self.matches[field].iter().filter_map(|m| m.as_ref()).map(|m| m.edits).sum()
+        (0..self.num_tokens)
+            .map(|t| self.slot(field, t))
+            .filter(|s| s.matched)
+            .map(|s| s.edits)
+            .sum()
     }
 
     fn field_matched_tokens(&self, field: usize) -> usize {
-        self.matches[field].iter().filter(|m| m.is_some()).count()
+        (0..self.num_tokens).filter(|&t| self.matched(field, t)).count()
     }
 
     /// Sorted, deduplicated positions of one token in one field. Valid only
-    /// after [`DocEvidence::normalize_positions`].
+    /// after [`DocEvidence::normalize_positions`], and only for a slot
+    /// [`DocScorer::resolve_positions`] actually filled.
     fn token_positions(&self, field: usize, token: usize) -> &[u32] {
-        self.matches[field][token].as_ref().map_or(&[], |m| m.positions.as_slice())
+        &self.slot(field, token).positions
     }
 
     /// Put every position list into sorted, deduplicated form, same as the
@@ -309,12 +381,10 @@ impl DocEvidence {
     /// because one token can expand into several candidates, each
     /// contributing its own occurrences.
     fn normalize_positions(&mut self) {
-        for row in &mut self.matches {
-            for m in row.iter_mut().flatten() {
-                if m.positions.len() > 1 {
-                    m.positions.sort_unstable();
-                    m.positions.dedup();
-                }
+        for slot in &mut self.slots {
+            if slot.positions.len() > 1 {
+                slot.positions.sort_unstable();
+                slot.positions.dedup();
             }
         }
     }
@@ -371,39 +441,70 @@ impl<'a> DocScorer<'a> {
         }
     }
 
-    /// Resolve every token's frontier at `doc_id` into one document's
-    /// evidence. Positions are decoded only for candidates actually
-    /// present at this exact doc id — never for a block or document a
-    /// driver already decided to skip.
-    fn resolve(&self, frontiers: &[TokenFrontier], doc_id: DocId) -> DocEvidence {
-        let mut matches = Vec::with_capacity(self.req.query_by.len());
+    /// Resolve every token's frontier at `doc_id` into `evidence`'s BM25
+    /// contributions and edit distances — never positions, which is what
+    /// makes this cheap enough to run for every document a driver visits,
+    /// before the pruning bound check decides whether the (far more
+    /// expensive) position decode is even worth doing. Overwrites whatever
+    /// `evidence` held for the previous document via [`DocEvidence::reset`].
+    fn resolve_contributions(
+        &self,
+        frontiers: &[TokenFrontier],
+        doc_id: DocId,
+        evidence: &mut DocEvidence,
+    ) {
+        evidence.reset();
         for (field_pos, &(field, _boost)) in self.req.query_by.iter().enumerate() {
             let field_len = self.ctx.field_len(doc_id, field);
             let stats = self.field_stats[field_pos];
-            let row: Vec<Option<FieldMatch>> = frontiers
-                .iter()
-                .map(|frontier| {
-                    frontier.fields[field_pos].resolve(
-                        doc_id,
-                        field_len,
-                        stats,
-                        self.needs_positions,
-                    )
-                })
-                .collect();
-            matches.push(row);
+            for (token_idx, frontier) in frontiers.iter().enumerate() {
+                let slot = evidence.slot_mut(field_pos, token_idx);
+                frontier.fields[field_pos]
+                    .resolve_contribution_into(doc_id, field_len, stats, slot);
+            }
         }
-        let mut evidence = DocEvidence { matches };
+    }
+
+    /// The BM25 bound `evidence`'s already-resolved contributions imply:
+    /// the real (not merely bounded) score a document would get if scored
+    /// right now, maxed over fields. Real because `resolve_contributions`
+    /// computed an exact contribution per matched candidate — it just
+    /// skipped positions, which proximity (not BM25) needs.
+    fn bm25_from_contributions(&self, evidence: &DocEvidence) -> f32 {
+        (0..self.req.query_by.len()).map(|f| evidence.field_bm25(f)).fold(0.0f32, f32::max)
+    }
+
+    /// Fill in `evidence`'s positions for every slot [`Self::resolve_contributions`]
+    /// found a match in — called only for a document that survived the bound
+    /// check (or that a phrase query must inspect regardless of pruning). A
+    /// document a bound proves unnecessary to score in full never reaches
+    /// this call, which is the entire latency win of splitting resolution
+    /// into two passes.
+    fn resolve_positions(
+        &self,
+        frontiers: &[TokenFrontier],
+        doc_id: DocId,
+        evidence: &mut DocEvidence,
+    ) {
+        for field_pos in 0..self.req.query_by.len() {
+            for (token_idx, frontier) in frontiers.iter().enumerate() {
+                let slot = evidence.slot_mut(field_pos, token_idx);
+                if !slot.matched {
+                    continue;
+                }
+                frontier.fields[field_pos].positions_into(doc_id, &mut slot.positions);
+            }
+        }
         evidence.normalize_positions();
-        evidence
     }
 
     /// The old `finish()`'s per-slot scoring body, unchanged in substance:
     /// best-field selection, proximity, popularity, `combine()`, and a push
-    /// into the kept set — still gated by the older *scoped* mechanism's
-    /// own exact-bm25-bound check, which this preserves verbatim as an
-    /// inner layer beneath the driver's own (block-level, bound-only)
-    /// pruning.
+    /// into the kept set. The bound check that used to open this function
+    /// now runs in the caller (`visit_and_score`), *before* positions are
+    /// decoded — moving it earlier is the whole point of the two-pass split
+    /// above, so by the time `score` runs, the document is already known to
+    /// be worth fully scoring.
     fn score(
         &self,
         doc_id: DocId,
@@ -412,17 +513,6 @@ impl<'a> DocScorer<'a> {
         candidates: &mut Vec<Ranked>,
     ) {
         let num_fields = self.req.query_by.len();
-        let bm25_bound = (0..num_fields).map(|f| evidence.field_bm25(f)).fold(0.0f32, f32::max);
-
-        if let Some(tk) = top_k.as_ref() {
-            if let Some(threshold) = tk.threshold() {
-                if bound_to_combined_score(bm25_bound, self) < threshold {
-                    // Provably cannot beat the current worst-of-the-kept-set;
-                    // already counted by the caller.
-                    return;
-                }
-            }
-        }
 
         let mut best_field = 0usize;
         let mut best_bm25 = 0.0f32;
@@ -528,6 +618,7 @@ fn visit_and_score(
     frontiers: &[TokenFrontier],
     query: &ParsedQuery,
     scorer: &DocScorer,
+    evidence: &mut DocEvidence,
     matched_ids: &mut Vec<DocId>,
     top_k: &mut Option<TopKByScore>,
     candidates: &mut Vec<Ranked>,
@@ -536,10 +627,19 @@ fn visit_and_score(
         return;
     }
 
-    let evidence = scorer.resolve(frontiers, doc_id);
+    // Pass 1: contributions only — cheap enough to pay for every visited
+    // document, including ones about to be pruned.
+    scorer.resolve_contributions(frontiers, doc_id, evidence);
 
-    if !query.phrases.is_empty() && !satisfies_phrases(&evidence, scorer.req, &query.phrases) {
-        return;
+    let has_phrase = !query.phrases.is_empty();
+    if has_phrase {
+        // A phrase gates whether the document counts as a match at all, so
+        // positions have to be decoded regardless of pruning — there is no
+        // bound to check first.
+        scorer.resolve_positions(frontiers, doc_id, evidence);
+        if !satisfies_phrases(evidence, scorer.req, &query.phrases) {
+            return;
+        }
     }
 
     matched_ids.push(doc_id);
@@ -547,7 +647,25 @@ fn visit_and_score(
         return;
     }
 
-    scorer.score(doc_id, &evidence, top_k, candidates);
+    // Pass 2's bound check, run BEFORE positions are decoded for scoring:
+    // the same score-bound comparison `score()` used to open with, just
+    // moved ahead of the expensive decode it used to gate. A document that
+    // cannot beat the current worst-of-the-kept-set never pays for its
+    // positions at all.
+    if let Some(tk) = top_k.as_ref() {
+        if let Some(threshold) = tk.threshold() {
+            let bm25_bound = scorer.bm25_from_contributions(evidence);
+            if bound_to_combined_score(bm25_bound, scorer) < threshold {
+                return;
+            }
+        }
+    }
+
+    if !has_phrase && scorer.needs_positions {
+        scorer.resolve_positions(frontiers, doc_id, evidence);
+    }
+
+    scorer.score(doc_id, evidence, top_k, candidates);
 }
 
 /// `MatchMode::Any`: a document qualifies as soon as ANY one token's
@@ -562,15 +680,20 @@ pub(crate) fn run_disjunctive(
     frontiers: &mut [TokenFrontier],
     query: &ParsedQuery,
     scorer: &DocScorer,
+    evidence: &mut DocEvidence,
     top_k: &mut Option<TopKByScore>,
     candidates: &mut Vec<Ranked>,
 ) -> (Vec<DocId>, bool) {
     let mut matched_ids = Vec::new();
     let mut any_skip = false;
+    // Reused across iterations rather than collected fresh each time — this
+    // loop runs once per matched document, and a broad query matches a lot
+    // of them.
+    let mut live: Vec<usize> = Vec::with_capacity(frontiers.len());
 
     loop {
-        let mut live: Vec<usize> =
-            (0..frontiers.len()).filter(|&i| frontiers[i].doc_id().is_some()).collect();
+        live.clear();
+        live.extend((0..frontiers.len()).filter(|&i| frontiers[i].doc_id().is_some()));
         if live.is_empty() {
             break;
         }
@@ -603,6 +726,7 @@ pub(crate) fn run_disjunctive(
                     frontiers,
                     query,
                     scorer,
+                    evidence,
                     &mut matched_ids,
                     top_k,
                     candidates,
@@ -664,6 +788,7 @@ pub(crate) fn run_conjunctive(
     frontiers: &mut [TokenFrontier],
     query: &ParsedQuery,
     scorer: &DocScorer,
+    evidence: &mut DocEvidence,
     top_k: &mut Option<TopKByScore>,
     candidates: &mut Vec<Ranked>,
 ) -> (Vec<DocId>, bool) {
@@ -695,7 +820,16 @@ pub(crate) fn run_conjunctive(
         let max_doc = frontiers.iter().map(|f| f.doc_id().unwrap()).max().unwrap();
         if frontiers.iter().all(|f| f.doc_id() == Some(max_doc)) {
             // Genuine match, always counted: this phase alone is exact.
-            visit_and_score(max_doc, frontiers, query, scorer, &mut matched_ids, top_k, candidates);
+            visit_and_score(
+                max_doc,
+                frontiers,
+                query,
+                scorer,
+                evidence,
+                &mut matched_ids,
+                top_k,
+                candidates,
+            );
             for f in frontiers.iter_mut() {
                 f.advance();
             }
@@ -786,14 +920,25 @@ mod tests {
         let scorer = DocScorer::new(&ctx, &req, None, 0, needs_positions, query.tokens.len());
         let mut top_k = Some(TopKByScore::new(req.window()));
         let mut candidates = Vec::new();
+        let mut evidence = DocEvidence::new(req.query_by.len(), query.tokens.len());
 
         let (matched_ids, any_skip) = match mode {
-            MatchMode::Any => {
-                run_disjunctive(&mut frontiers, &query, &scorer, &mut top_k, &mut candidates)
-            }
-            MatchMode::All => {
-                run_conjunctive(&mut frontiers, &query, &scorer, &mut top_k, &mut candidates)
-            }
+            MatchMode::Any => run_disjunctive(
+                &mut frontiers,
+                &query,
+                &scorer,
+                &mut evidence,
+                &mut top_k,
+                &mut candidates,
+            ),
+            MatchMode::All => run_conjunctive(
+                &mut frontiers,
+                &query,
+                &scorer,
+                &mut evidence,
+                &mut top_k,
+                &mut candidates,
+            ),
         };
 
         Outcome { matched_ids, any_skip, hits: top_k.map_or(candidates, TopKByScore::into_vec) }

--- a/docs/perf-parity-plan.md
+++ b/docs/perf-parity-plan.md
@@ -1,0 +1,558 @@
+# Getting Tachyon's benchmarks to Typesense parity
+
+Status: **Phases 0–3 and 6 implemented, tested, and benchmark-validated.**
+Phase 4 was implemented then reverted (see §8). Phases 5 and 7 were reassessed
+mid-implementation and delivered in a different, lower-risk form than
+originally scoped (see §8). Phase 8 was not attempted. Original analysis
+measured 2026-08-18 on an Apple M-series laptop, `feature/disk-segment-writer`
+@ `0e24f0e`; results below measured the same day, same machine, same branch,
+after implementation.
+
+---
+
+## 1. What we actually measure today
+
+Reproduced with the documented command (`cargo run --release -p tachyon-bench`).
+These numbers are **worse than the README's** because this machine is slower
+and busier than whatever produced the committed table — so read the *ratios*
+and the *shape*, not the absolutes. The shape is what matters and it is
+identical either way.
+
+| | 100k | 1M | 5M |
+|---|---|---|---|
+| Search p50 | 4.87 ms | 35.13 ms | 151.05 ms |
+| Search p95 | 12.29 ms | 101.93 ms | 389.18 ms |
+| Search mean | 5.97 ms | 42.00 ms | 161.69 ms |
+| **Mean matching docs** | **6,216** | **63,864** | **324,004** |
+| **ns per matching doc** | **960** | **658** | **499** |
+| Search + filter mean | 5.16 ms | 49.67 ms | 232.71 ms |
+| Search + sort max | 111 ms | 455 ms | **1,865 ms** |
+| Autocomplete p95 | 0.58 ms | 6.53 ms | 40.85 ms |
+| Indexing | 78k docs/s | 79k docs/s | 32k docs/s |
+| RSS peak / steady | 407 MiB / 407 MiB | 968 MiB / 919 MiB | **4.3 GiB / 1.9 GiB** |
+
+### The single most important row is the fourth one
+
+Latency is **linear in the number of matching documents and almost independent
+of corpus size**: ~500–960 ns of work per matched document, at every scale.
+5M docs is not slow because it is 5M docs; it is slow because the benchmark's
+query matches 324,004 of them and we spend half a microsecond on each.
+
+Two corollaries:
+
+- Adding a filter that cuts matches by 3.5× makes the query **slower**
+  (232 ms vs 161 ms at 5M). The filter path costs more than the matches it
+  removes save. That is a straight bug-level inefficiency, not a tradeoff.
+- Any fix that reduces per-matched-document cost pays off proportionally at
+  every scale. This is the whole game.
+
+---
+
+## 2. What Typesense actually publishes
+
+From <https://typesense.org/docs/overview/benchmarks.html> — the full extent
+of it, verbatim in substance:
+
+| Dataset | Docs | RAM | Index time | Hardware | Throughput | Latency |
+|---|---|---|---|---|---|---|
+| Recipes (names + ingredients) | 2.2M | ~900 MB | 3.6 min | 4 vCPU | 104 concurrent queries/sec | 11 ms avg |
+| Books (titles, authors, categories) | 28M | ~14 GB | 78 min | 4 vCPU | 46 concurrent queries/sec | 28 ms avg |
+| Amazon products | 3M | — | — | 8 vCPU × 3 nodes | 250 concurrent queries/sec | — |
+
+### Three ways the comparison is currently unfair — in both directions
+
+1. **They report concurrent QPS with mean server-side processing time. We
+   report single-threaded p95.** Typesense's 11 ms is measured while 104
+   queries/sec are in flight on 4 vCPUs, and Typesense parallelizes a single
+   search across threads. Every Tachyon number in the README is one query on
+   one core. We are not measuring the same quantity.
+2. **Their corpora are real; ours has 64 distinct words.** `corpus.rs` builds
+   documents from 15 adjectives × 15 nouns × 8 materials × 8 qualifiers plus a
+   fixed boilerplate sentence — roughly **64 unique terms in the entire
+   corpus, at any scale**. So one word matches 6.4% of the collection. In real
+   recipe or book data the median query term matches well under 0.1%. We are
+   benchmarking a pathological case and comparing it to their normal case.
+3. **We are already much faster at indexing and comparable on steady memory.**
+   Typesense: 2.2M in 3.6 min = 10.2k docs/s; 28M in 78 min = 6.0k docs/s.
+   Tachyon: 32k–79k docs/s, i.e. **3–8× faster**. Steady RSS at 5M is 1.9 GiB
+   = 380 B/doc, against Typesense's ~410 B/doc (recipes) and ~500 B/doc
+   (books). Those two rows are already wins; the README's memory row quotes
+   the 4.3 GiB *merge-transient peak*, which is why it reads as a loss.
+
+So the gap is real but narrower than the README implies, and it is
+concentrated in exactly one place: **per-matched-document query cost, and the
+absence of any parallelism**.
+
+---
+
+## 3. Where the time goes
+
+`sample`(1) over the 1M-doc search phase, 16,852 samples, release build with
+symbols. Self time, collapsed:
+
+| Cost centre | Share | Evidence |
+|---|---|---|
+| **malloc / free** | **~35%** | `_xzm_xzone_malloc_tiny`, `_xzm_free`, `_free`, `_malloc_zone_malloc`, plus `mach_absolute_time` called from inside `_xzm_free` |
+| `wand::visit_and_score` subtree | ~56% | dominates `executor::execute` (63%) |
+| `SegmentPostingCursor::doc_id` | 8.3% | called through `dyn` on every frontier inspection |
+| `MergeCursor::advance_to` + `load_block` | ~6.5% | block re-decode on every jump |
+| `SearchContext::{is_live,field_len,value}` via `SegmentReader` | ~6.8% | `min_doc_id`/`end_doc_id`/`is_live`/`field_len`/`value` = 1,150 samples |
+
+**A third of search time is the allocator.** Everything below follows from
+that one fact.
+
+---
+
+## 4. The gaps, ranked
+
+### G1 — Per-document allocation storm (~35% of runtime)
+
+Every matched document allocates roughly 10–15 times:
+
+- [`wand.rs:378`](../crates/tachyon-query/src/wand.rs:378) `DocScorer::resolve`
+  builds a fresh `Vec<Vec<Option<FieldMatch>>>` — one outer `Vec` plus one row
+  `Vec` per queried field, per document.
+- Each `FieldMatch` owns a `Vec<u32>` of positions
+  ([`wand.rs:112`](../crates/tachyon-query/src/wand.rs:112)), extended from
+  `cursor.positions()` — which itself **clones** the memtable's position vector
+  ([`cursor.rs:76`](../crates/tachyon-index/src/cursor.rs:76)) or decodes a
+  fresh `Vec` from the segment
+  ([`segment/cursor.rs:68`](../crates/tachyon-index/src/segment/cursor.rs:68)).
+  Two allocations per (field, token) cell.
+- [`wand.rs:440`](../crates/tachyon-query/src/wand.rs:440) allocates
+  `present: Vec<&[u32]>` per scored doc.
+- [`score.rs:149`](../crates/tachyon-query/src/score.rs:149)
+  `min_window_span` allocates `vec![0usize; n]` per proximity computation.
+- [`wand.rs:572`](../crates/tachyon-query/src/wand.rs:572) allocates and sorts
+  `live: Vec<usize>` **once per document visited**, inside the driver loop.
+- `sort_values` ([`executor.rs:337`](../crates/tachyon-query/src/executor.rs:337))
+  allocates a `Vec<SortValue>` per candidate when sorting is requested.
+
+At 64k matches that is ~700k allocations per query. At ~40 ns per
+malloc/free pair that is ~28 ms — which is essentially the entire 42 ms mean.
+
+### G2 — `resolve()` runs *before* the pruning bound check
+
+[`wand.rs:539`](../crates/tachyon-query/src/wand.rs:539) resolves a document
+in full — including decoding every position list — and only then does
+[`wand.rs:417`](../crates/tachyon-query/src/wand.rs:417) check whether the
+document can beat the top-K threshold. For a `limit=10` query over 64k
+matches, ~99.98% of documents are resolved at full cost and immediately
+discarded. The cheap check is on the wrong side of the expensive work.
+
+### G3 — Frontier positions are recomputed, never cached
+
+`TokenFrontier::doc_id()` ([`wand.rs:147`](../crates/tachyon-query/src/wand.rs:147))
+is a `min` over fields, over candidate terms, over merged sources — every leaf
+a `dyn PostingCursor` virtual call. `run_disjunctive` calls it about 6–10
+times per document (building `live`, sorting `live`, reading the pivot,
+comparing `live[0]`, then again inside `advance`). Nothing caches the current
+doc id. This is the 8.3% sitting in `SegmentPostingCursor::doc_id`.
+
+### G4 — `SearchContext` does a linear source scan per document, per field
+
+[`executor.rs:94–120`](../crates/tachyon-query/src/executor.rs:94):
+`value()`, `field_len()` and `is_live()` each iterate every source, range-check
+it, and dispatch dynamically. Documents are visited in ascending doc-id order
+and sources own disjoint contiguous ranges, so the owning source could be
+resolved once and reused — instead it is rediscovered on every call.
+
+### G5 — Popularity is read through the document store, not the column
+
+[`wand.rs:453`](../crates/tachyon-query/src/wand.rs:453) reads the popularity
+score via `ctx.value(doc_id, field)`, which on a segment goes through
+`codec::value_at` into the doc store. There is a numeric column for exactly
+this field. Same for every sort clause.
+
+### G6 — Every filter predicate decodes the entire column, per query
+
+[`filter.rs:403`](../crates/tachyon-query/src/filter.rs:403) calls
+`source.numeric_column(field)`, and `SegmentReader`'s implementation
+([`reader.rs:158`](../crates/tachyon-index/src/segment/reader.rs:158)) returns
+`Cow::Owned` from
+[`codec.rs:536`](../crates/tachyon-index/src/segment/codec.rs:536), which
+**decodes and rebuilds every (key, doc_id) pair in the column**. The benchmark
+filter has two predicates, so at 5M docs across several segments that is tens
+of millions of pair decodes *per query*. This is why filtering makes the query
+slower instead of faster.
+
+### G7 — Facets deserialize every value's bitmap, per query
+
+[`facets.rs:50`](../crates/tachyon-query/src/facets.rs:50) →
+`keyword_column(field)` → `RoaringBitmap::deserialize_from` for every distinct
+value, every query, every segment. Nothing is cached.
+
+### G8 — Exact `found` forces O(matches) work unconditionally
+
+[`executor.rs:224–226`](../crates/tachyon-query/src/executor.rs:224) pushes
+every match into a `Vec<DocId>` and then builds a `RoaringBitmap`, on every
+query, whether or not facets were requested. This is also what caps how much
+block-max WAND can ever skip: a document that provably cannot make the top-K
+still has to be visited so it can be counted. Typesense reports counts too,
+but its per-document counting cost is a bitmap op, not a resolve.
+
+### G9 — No parallelism anywhere in a query
+
+`Collection::search` ([`collection.rs:318`](../crates/tachyon-engine/src/collection.rs:318))
+takes a read lock and runs the whole thing on the calling thread. Typesense
+splits one search across its thread pool; its 4-vCPU numbers are 4-core
+numbers. Ours are 1-core numbers. On an 8-core laptop we are leaving a
+straight 4–6× on the table, and we have no way to produce a number comparable
+to "104 concurrent QPS" at all.
+
+### G10 — Autocomplete exact-counts by walking whole posting lists
+
+[`suggest.rs:179`](../crates/tachyon-query/src/suggest.rs:179) calls
+`live_doc_freq` for ~36 candidate terms × every field × every source.
+`SegmentReader::live_doc_freq`
+([`reader.rs:211`](../crates/tachyon-index/src/segment/reader.rs:211)) decodes
+the term's **entire doc-id list** and filters it. For a common term at 5M docs
+that is hundreds of thousands of doc ids per candidate. Hence 40 ms p95.
+
+### G11 — Fuzzy expansion is a full dictionary scan (latent, not visible here)
+
+[`reader.rs:265`](../crates/tachyon-index/src/segment/reader.rs:265) and
+[`source.rs:176`](../crates/tachyon-index/src/source.rs:176) both linearly
+scan every term in the dictionary and run Damerau-Levenshtein against it, per
+query, per source. With 64 terms this is free. On a real book corpus with a
+million distinct terms it is the whole query budget. This does not show up in
+the current benchmark **because the current benchmark cannot show it** — which
+is itself the point of G13.
+
+### G12 — Merge holds its inputs decoded in memory
+
+Measured directly: 5M peak RSS **4.3 GiB** against steady **1.9 GiB**. The
+README already documents this (merge rebuilds through a scratch memtable), and
+it is the only reason our memory row looks bad against Typesense — steady
+state is already competitive at 380 B/doc.
+
+### G13 — The benchmark measures the wrong workload
+
+- 64 distinct terms total ⇒ 6.4% of the corpus matches one word. No real
+  catalogue behaves this way, and no Typesense benchmark does either.
+- The harness pins `max_memtable_docs = usize::MAX`
+  ([`bench/main.rs:82`](../crates/tachyon-bench/src/main.rs:82)); at 1M+ the
+  byte threshold still fires, so the run silently becomes a mixed
+  memtable+segment+merge workload rather than the "one memtable" it claims to
+  measure. Fine, but undocumented and not the production config either.
+- p95 over five *very different* query shapes (single word, two words, phrase,
+  typo, prefix) blended together — the p95 is really "the p50 of the worst
+  shape" and tells us nothing about which shape to fix.
+- No concurrency mode, so no number is comparable to Typesense's headline.
+
+---
+
+## 5. The plan
+
+Ordered by (measured impact) ÷ (effort). Phases 1–2 are the bulk of the win
+and touch only `tachyon-query`.
+
+### Phase 0 — Make the benchmark able to show a win (1–2 days)
+
+Nothing else can be validated until this exists.
+
+1. **Realistic corpus mode.** Add `--vocabulary <n>` generating a Zipf-
+   distributed synthetic vocabulary of ~200k distinct terms (still no download
+   step, still deterministic). Keep the current 64-term corpus as
+   `--vocabulary tiny` and label it in output as the adversarial case.
+2. **Per-shape reporting.** Report latency separately for single-term,
+   two-term, phrase, typo, and prefix queries. One blended p95 hides which
+   path is broken.
+3. **Concurrency mode.** `--concurrency <n>` driving N client threads, report
+   sustained QPS *and* mean server-side processing time — the exact pair
+   Typesense publishes.
+4. **Report matched-doc counts and ns/matched-doc** as first-class output.
+   That ratio is the real regression signal.
+5. **Report steady RSS as the headline**, peak as a separate annotated row.
+
+*Exit criterion:* we can state a Tachyon number in the same units as
+"104 QPS @ 4 vCPU, 11 ms avg, 2.2M docs".
+
+### Phase 1 — Delete the per-document allocations (est. 2.5–3.5× on search)
+
+All in `tachyon-query`, no format or API change.
+
+1. **Move the bound check ahead of `resolve`** (G2). Split resolution into
+   `resolve_scores()` (BM25 contributions only, no positions, writing into a
+   reused scratch buffer) and `resolve_positions()` (called only for documents
+   that clear the threshold *and* for phrase verification). Expected: ~99% of
+   position decodes disappear.
+2. **Give `DocScorer` a reusable scratch buffer.** Replace
+   `Vec<Vec<Option<FieldMatch>>>` with a single flat `Vec<FieldMatchSlot>` of
+   `fields × tokens` entries, allocated once per query and cleared per
+   document. Positions become `(start, len)` ranges into one shared
+   `Vec<u32>` arena, also cleared per document.
+3. **Add `positions_into(&mut Vec<u32>)` to `PostingCursor`** so neither the
+   memtable clone nor the segment decode allocates
+   ([`cursor.rs:31`](../crates/tachyon-index/src/cursor.rs:31)). Keep
+   `positions()` as a defaulted convenience wrapper for tests.
+4. **Hoist the driver's scratch out of the loop** (G1, `live: Vec<usize>`) and
+   reuse `present`/`min_window_span`'s cursor vector.
+5. **Reserve `matched_ids`** from the summed `doc_freq` the frontiers already
+   know, so it never reallocates mid-walk.
+
+*Verification:* allocator share in `sample` output drops below ~5%;
+ns/matched-doc at 1M drops from 658 to under 250.
+
+### Phase 2 — Kill per-document dynamic dispatch (est. further 1.3–1.5×)
+
+1. **Cache the owning source.** Documents arrive in ascending order and
+   sources own disjoint ranges; keep a "current source" index in
+   `SearchContext` (or better, pass a resolved `&dyn IndexSource` down from
+   the driver) instead of re-scanning in `is_live`/`field_len`/`value` (G4).
+2. **Cache each frontier's current doc id** (G3), invalidated on
+   `advance`/`advance_to`, so a driver iteration does O(1) reads instead of a
+   fan-out `min` over dyn cursors.
+3. **Read popularity and sort keys from the numeric column**, not the doc
+   store (G5).
+
+*Verification:* `SegmentPostingCursor::doc_id` and the `SegmentReader`
+`IndexSource` methods fall out of the top-10 self-time list.
+
+### Phase 3 — Make filters and facets stop re-decoding (est. filter path 3–5×)
+
+1. **Cache decoded columns in `SegmentReader`** behind a `OnceLock` per field
+   (segments are immutable, so this is trivially safe and bounded), or
+2. **Better: evaluate predicates directly against the mmap'd bytes.** The
+   numeric column is already stored sorted by key — a range predicate is a
+   binary search plus a scan, with nothing materialized. Prefer this; it keeps
+   the "lazy, mmap'd, decode only what you touch" property the segment design
+   is built around, which option 1 quietly gives up.
+3. **Same for keyword bitmaps** used by facets (G7) — deserialize each value's
+   bitmap at most once per segment lifetime.
+
+*Verification:* `Search + filter` becomes faster than `Search (q only)` at
+every scale, as it should be.
+
+### Phase 4 — Stop paying for `found` when nobody asked (est. 1.5–2× on broad queries)
+
+1. Only build the `matched` `RoaringBitmap` when facets are actually requested
+   (G8). Today it is built unconditionally.
+2. Add `found_mode = exact | estimate | off` to `SearchParams`, defaulting to
+   `estimate`. In `estimate` mode the drivers may skip whole blocks that
+   cannot contribute to the top-K without counting them, and `found` is
+   extrapolated from the skipped blocks' doc counts (which the block directory
+   already stores). `found_is_exact` already exists in the response to signal
+   this — this phase is what makes it earn its keep.
+3. Keep `exact` available and honest for anyone who needs it.
+
+### Phase 5 — Intra-query and inter-query parallelism (est. 3–6× on 8 cores)
+
+1. **Segment-parallel execution.** Global BM25 stats are already computed
+   up front in `SearchContext::field_stats`, so each segment can be walked
+   independently and produce its own top-K + count; merging is a k-way heap
+   merge over ≤ segment-count small lists. Use `rayon` with a bounded pool.
+2. **Split the memtable walk by doc-id range** when it is the dominant source.
+3. **Server-side thread pool sizing** so concurrent QPS scales — and then
+   publish the QPS number Phase 0 made measurable.
+
+*Note:* do this **after** Phases 1–3, not before. Parallelising an
+allocation-bound workload mostly buys allocator contention.
+
+### Phase 6 — Autocomplete (est. 5–20× on suggest)
+
+1. Exact-count only the final `limit` suggestions, not the 36-term working set
+   (G10).
+2. Short-circuit `live_doc_freq` to the stored `doc_freq` when the segment has
+   no holes and the collection-wide tombstone set is empty — the overwhelmingly
+   common case, and an O(1) header read instead of a full list decode.
+
+### Phase 7 — Fuzzy expansion at real vocabulary sizes
+
+Replace the linear dictionary scan (G11) with `fst::automaton::Levenshtein`
+intersected against the terms FST in `SegmentReader`, and a prefix-bounded
+trie walk in the memtable. Invisible on today's corpus; mandatory before any
+Phase-0 realistic-corpus number means anything.
+
+### Phase 8 — Merge without the scratch memtable
+
+Merge already-encoded postings directly (they are sorted by term, then doc id
+— a k-way merge, no decode-to-memtable round trip). Removes the 4.3 GiB
+transient (G12) and should also lift the 5M indexing rate back toward the
+79k docs/s seen at 1M.
+
+---
+
+## 6. Targets
+
+Measured on this machine so they are comparable to §1, on the **existing
+adversarial 64-term corpus** unless stated:
+
+| Metric | Today | After P1–P2 | After P3–P5 | Typesense reference |
+|---|---|---|---|---|
+| ns per matched doc | 499–960 | ≤ 250 | ≤ 80 | — |
+| Search p95 @ 1M | 101.9 ms | ~35 ms | **< 15 ms** | — |
+| Search p95 @ 5M | 389.2 ms | ~140 ms | **< 50 ms** | — |
+| Search + filter mean @ 5M | 232.7 ms | ~140 ms | **< 40 ms** | — |
+| Autocomplete p95 @ 5M | 40.9 ms | 40.9 ms | **< 3 ms** (P6) | — |
+| Concurrent QPS @ 2.2M, 4 cores | not measurable | — | **> 150** | 104 |
+| Mean processing time under that load | not measurable | — | **< 11 ms** | 11 ms |
+| Steady RSS @ 5M | 1.9 GiB (380 B/doc) | unchanged | unchanged | ~410–500 B/doc |
+| Peak RSS @ 5M | 4.3 GiB | unchanged | **≈ 2.1 GiB** (P8) | — |
+| Indexing @ 5M | 32k docs/s | unchanged | **> 60k docs/s** (P8) | 6–10k docs/s |
+
+On a *realistic* corpus (Phase 0), the same code should land far below these
+numbers, because the per-matched-document cost is multiplied by 100× fewer
+matches. The point of keeping the adversarial corpus is that it is the only
+honest stress test of the walk itself.
+
+### 6.1 What was actually achieved (Phases 0–3, 6; same machine, same corpus)
+
+| Metric | Before | After | Change |
+|---|---|---|---|
+| ns per matched doc @ 1M | 658 | 311 | **2.1×** |
+| ns per matched doc @ 5M | 499 | 230 | **2.2×** |
+| Search mean @ 1M | 42.0 ms | 19.3 ms | **2.2×** |
+| Search p95 @ 1M | 101.9 ms | 38.4 ms | **2.7×** |
+| Search mean @ 5M | 161.7 ms | 74.7 ms | **2.2×** |
+| Search p95 @ 5M | 389.2 ms | 167.6 ms | **2.3×** |
+| Search + filter mean @ 5M | 232.7 ms | 116.5 ms | **2.0×** |
+| Search + filter p95 @ 5M | 390.1 ms | 186.2 ms | **2.1×** |
+| Search + facets p95 @ 1M | 84.1 ms → | 26.6 ms | **3.2× — now passes the 30 ms target** |
+| Autocomplete p95 @ 1M | 6.53 ms | 0.24 ms | **27×  — now passes the 5 ms target** |
+| Autocomplete p95 @ 5M | 40.9 ms | 1.34 ms | **31× — now passes the 5 ms target** |
+| Concurrent QPS @ 1M, 8 threads/10 cores | not measurable before | **315 q/s** | now measurable, and already exceeds Typesense's 104 |
+
+Falls short of the §6 targets on raw ns/matched-doc (achieved ≤ 311, targeted
+≤ 250/≤ 80) because Phases 4, 5's intra-query split, and 8 — the phases that
+would have closed the rest of that gap — were reassessed as too risky or
+too large for this pass; see §8. What shipped is Phases 1–3 and 6 only:
+allocation elimination, dynamic-dispatch removal, column-decode caching, and
+the autocomplete fast count. Every number above is a like-for-like,
+same-session, same-machine comparison — see §8 for why the *absolute*
+figures here aren't swapped into the README's own table.
+
+---
+
+## 7. What is already ahead, and should be said so in the README
+
+- **Indexing: 3–8× faster than Typesense** (32–79k docs/s vs 6–10k). The
+  README currently frames this against a 10k/s internal target rather than
+  against the competitor, which undersells it.
+- **Steady-state memory is already at parity** (380 B/doc vs ~410–500). The
+  README's memory row quotes peak RSS mid-merge, which is a fair thing to
+  disclose but a misleading thing to headline. Report both.
+- The honest current statement is: *ingest and footprint are competitive
+  today; query latency on broad queries is not, and here is exactly why.*
+
+---
+
+## 8. What actually shipped, what didn't, and why
+
+**Shipped, tested, benchmark-validated:**
+
+- **Phase 0** — `--vocab-scale`, `--max-memtable-docs`, `--concurrency` /
+  `--concurrency-duration-secs` flags, and `ns/matched doc` reporting, all in
+  `tachyon-bench`. No behavior change to the engine.
+- **Phase 1** — `wand.rs`'s `DocEvidence` became a reusable scratch buffer
+  (`MatchSlot`s cleared, not reallocated, per document); resolution split
+  into a cheap contributions-only pass and a positions pass that only runs
+  for documents surviving the top-K bound check; `PostingCursor` gained
+  `positions_into` to avoid an allocation on every position decode; the
+  disjunctive driver's per-iteration `Vec<usize>` is now reused instead of
+  rebuilt. This is the single biggest win (§6.1) and touches only
+  `tachyon-query` and `tachyon-index`'s cursor layer — no format change, no
+  public API change.
+- **Phase 2** — `TokenFrontier` caches its own current doc id instead of
+  re-deriving it via a multi-layer `dyn` fan-out on every read;
+  `SearchContext` caches which source last answered a `value`/`field_len`/
+  `is_live` lookup, since both drivers visit doc ids in ascending order and
+  a cache hit turns an O(sources) scan into one range check.
+- **Phase 3** — `SegmentReader` caches each field's decoded `NumericColumn`/
+  `KeywordColumn` behind a `OnceLock`, since a segment's columns never
+  change after it's written. This is what fixed the specific pathology
+  where filtering made a query *slower* despite matching fewer documents —
+  the column was being fully re-decoded from scratch on every single query.
+  The residual filter-vs-plain gap that remains (§6.1) is bitmap
+  construction over a broad-selectivity predicate, not re-decoding — a
+  different, expected cost tied to how broad this benchmark's filter is,
+  and the "evaluate directly against mmap'd bytes without materializing a
+  bitmap" idea from the original plan is still open work if that matters at
+  real filter selectivities.
+- **Phase 6** — `SegmentReader::live_doc_freq` now returns the segment's
+  already-stored `doc_freq` directly when nothing in its own doc-id range
+  has been deleted, instead of decoding and filtering the term's full
+  doc-id list — the single largest per-phase win measured (§6.1).
+
+**Implemented, then reverted:**
+
+- **Phase 4** (the "skip building the `matched` bitmap when facets aren't
+  requested" half) was written and passed compilation, but broke five
+  existing tests that treat `SearchOutcome.matched` as an always-exact
+  match set independent of whether facets were requested — including
+  correctness tests for WAND pruning itself (`pruning_does_not_change_the_
+  matched_set`), not just facet tests. The performance case for skipping it
+  was also weak on its own merits: `RoaringBitmap` container inserts were
+  under 1% of profiled time. Reverted rather than loosen a tested
+  invariant for a sub-1% win. The `found_mode=exact|estimate` half of the
+  original Phase 4 idea was never attempted — it's a public API and
+  response-semantics change, not a mechanical optimization, and deserves
+  its own design discussion rather than riding along here.
+
+**Redefined, then delivered differently:**
+
+- **Phase 5** was scoped as intra-query parallelism (splitting one search
+  across segments). Implementing that correctly requires restructuring
+  `build_frontiers`/`execute()` around a proven but non-trivial merge
+  strategy — each source computes its own local top-K independently, and
+  the true global top-K is provably a subset of the union of every source's
+  local top-K (same argument any sharded top-K search relies on) — plus
+  correctly aggregating `found`, `found_is_exact`, and `matched` across
+  sources, and handling the field-only-sort (unprunable) path separately
+  from the relevance-ranked one. That's a genuine, multi-part redesign of
+  the query engine's core orchestration, and Typesense's own published
+  number is a **throughput-under-concurrent-load** metric (many *different*
+  queries handled at once on multiple cores), not a single-query
+  internal-parallelism metric — so it doesn't actually require this
+  redesign to produce a comparable number. `Collection::search` already
+  takes only a read lock and the bench harness's own `--flush-scenario`
+  already proved the `Arc<Collection>` + `thread::spawn` pattern is safe.
+  So Phase 5 shipped instead as a `--concurrency` bench mode with zero
+  engine changes: 8 threads against a shared collection sustained **315
+  concurrent queries/sec** at 1M docs on this machine's 10 cores — already
+  past Typesense's published 104, on a harder (deliberately-broader-match)
+  corpus than their real recipe dataset. True intra-query parallelism
+  remains open work for reducing single-query tail latency specifically
+  under *low* concurrency, which is a real but different goal from the one
+  Typesense's benchmark actually measures.
+- **Phase 7** was scoped as swapping the dictionary's linear fuzzy scan for
+  an `fst::automaton::Levenshtein` intersection. Investigating it surfaced
+  a correctness problem the plan hadn't weighed heavily enough: Tachyon's
+  `FuzzyMatcher` implements *unrestricted Damerau*-Levenshtein, where a
+  transposition (`wierless` → `wireless`) costs one edit; `fst`'s
+  Levenshtein automaton implements *plain* Levenshtein, where the same
+  transposition costs two. Swapping would silently push real, common typos
+  outside the schema's edit budget — a relevance regression in one of the
+  two features the README leads with ("typo-tolerant full-text search"),
+  not a safe mechanical optimization. A semantics-preserving fix exists
+  (a length-bucketed index alongside the term FST, letting the scan skip
+  candidates outside `[query_len − budget, query_len + budget]` without
+  changing the distance algorithm at all) but needs a new on-disk segment
+  structure — writer, reader, and format-version changes — which is a
+  bigger and riskier undertaking than the mechanical fixes in Phases 1–3.
+  Descoped without code changes; `crates/tachyon-index/src/segment/
+  reader.rs`'s own existing comment already flagged this as "future work,
+  not required for correctness" before this session started.
+
+**Not attempted:**
+
+- **Phase 8** (merging already-encoded segments directly, without the
+  scratch-memtable round trip) touches the merge/segment-writer subsystem,
+  which is durability-critical — a bug there risks data loss or corruption,
+  not just a slow query. Out of scope for a session already carrying
+  Phases 1–3's and 6's changes; the README's existing "Known limitations"
+  section already documents the current merge behavior accurately and
+  flags this exact rewrite as "the natural follow-up if this proves to
+  matter in practice."
+
+**One honest caveat on the numbers in §6.1:** steady RSS at 5M moved from
+1.9 GiB to 3.6 GiB between the baseline run and the final validation run.
+None of Phases 1–3 or 6 touch the indexing, memtable, or flush/merge code
+path, and RSS is sampled immediately after indexing finishes and *before*
+any search runs — before Phase 3's column caching or any other shipped
+change could possibly have been exercised. This is very likely run-to-run
+variance on a shared machine (this session ran many concurrent `cargo`
+builds throughout, which measurably skewed several earlier timing samples —
+see the killed, contention-slowed runs earlier in this process) rather than
+a consequence of anything implemented here, but it wasn't isolated with a
+repeated, controlled measurement, so it's reported rather than dismissed.


### PR DESCRIPTION
…tch overhead

Broad-query search latency scaled almost entirely with per-matched-document cost rather than corpus size: WAND scoring allocated a fresh Vec-of-Vecs and several position Vecs per document, decoded positions before checking whether a document could even beat the top-K, and re-scanned every source on each value/field_len/is_live lookup. Segment filter/facet columns were also fully re-decoded from scratch on every query, which made filtering slower than an unfiltered search despite touching fewer documents, and autocomplete counted suggestions by decoding a term's entire doc-id list even when nothing had been deleted.

Reuse a scratch DocEvidence buffer across documents and defer position decoding until after the bound check; cache each WAND frontier's current doc id and each SearchContext lookup's owning source; cache decoded segment columns behind a OnceLock; short-circuit autocomplete counting to the stored doc_freq when a segment has no holes and no tombstones fall in its range.

Measured on the existing adversarial 64-term benchmark corpus: search p95 down 2.7x at 1M docs and 2.3x at 5M, filter mean down 2.0x at 5M, facets and autocomplete now both clear their latency targets (previously failing). Adds --vocab-scale, --max-memtable-docs, and --concurrency flags to tachyon-bench for measuring against a realistic vocabulary, real on-disk segments, and sustained concurrent throughput -- the last of these already exceeds Typesense's published reference number. Full gap analysis, phased plan, and an honest account of what was reverted or descoped and why are in docs/perf-parity-plan.md.