### PR TITLE
Stream segment flush and merge to bounded memory (format v4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,7 @@ minutes. It is not a vector database and not a RAG engine; it does one thing.
 docker run -p 8108:8108 ghcr.io/tachyon-search/tachyon:latest
 ```
 
-> See [Known limitations](#known-limitations) before you rely on it — in
-> particular, **a merge briefly holds everything it's folding together in
-> memory at once**, a real cost worth accounting for when tuning
-> `--merge-fan-in` on a memory-constrained deployment.
+> See [Known limitations](#known-limitations) before you rely on it.
 
 ---
 
@@ -102,18 +99,20 @@ broader than real traffic, and deliberately so, because it is the expensive case
 
 | | 100k documents | 1M documents | 5M documents | Target |
 |---|---|---|---|---|
-| Search p95 | **3.6 ms** | 31.6 ms | 160.3 ms | < 30 ms |
-| Search p99 | **4.3 ms** | 34.3 ms | 171.5 ms | < 60 ms |
-| Autocomplete p95 | **0.35 ms** | 0.24 ms | 1.4 ms | < 5 ms |
-| Indexing | **182k docs/sec** | 140k docs/sec | 50k docs/sec | 10k docs/sec |
-| Memory (steady RSS) | 403 MiB | 968 MiB | 3.4 GiB | — |
-| Memory (peak RSS) | 403 MiB | 999 MiB | 5.2 GiB | — |
+| Search p95 | **3.4 ms** | 34.4 ms | 175.1 ms | < 30 ms |
+| Search p99 | **4.0 ms** | 35.5 ms | 181.7 ms | < 60 ms |
+| Autocomplete p95 | **0.29 ms** | 0.23 ms | 1.8 ms | < 5 ms |
+| Indexing | **196k docs/sec** | 145k docs/sec | 88k docs/sec | 10k docs/sec |
+| Memory (steady RSS) | 405 MiB | 606 MiB | 895 MiB | — |
+| Memory (peak RSS) | 405 MiB | 646 MiB | 1.5 GiB | — |
 
 Both measured right after indexing finishes, before any searches run. Steady
 is current RSS at that point — what's resident most of the time. Peak is
 `getrusage`'s kernel-tracked high-water mark since process start, which also
-catches any transient spike indexing passed through on the way there; at 5M
-documents the two diverge meaningfully; at 100k they don't.
+catches any transient spike indexing passed through on the way there; at 100k
+documents the whole corpus stays in one memtable (no segment ever gets
+written), so steady and peak are identical there by construction, not
+coincidence.
 
 Reproduce:
 
@@ -121,11 +120,15 @@ Reproduce:
 cargo run --release -p tachyon-bench -- --documents 1000000 --queries 2000
 ```
 
-Indexing throughput beats the target by more than an order of magnitude, and
-autocomplete now clears its target at every scale measured. Search meets the
-latency target at 100k documents; at 1M it misses by a hair (31.6 ms vs. the
-30 ms target) and at 5M it still misses by a wide margin **on this corpus**;
-see [Known limitations](#known-limitations).
+Indexing throughput beats the target by nearly an order of magnitude at 5M
+documents and more at smaller scales, and autocomplete clears its target at
+every scale measured. Search meets the latency target at 100k documents; at
+1M and 5M it misses **on this corpus** — see
+[Known limitations](#known-limitations) — but memory no longer moves in
+lockstep with corpus size the way it used to: peak RSS at 5M documents fell
+from 5.2 GiB to 1.5 GiB after the streaming segment writer and merge
+described below replaced a design that rebuilt each merge's input through a
+scratch in-memory index before re-encoding it.
 
 ---
 
@@ -133,25 +136,30 @@ see [Known limitations](#known-limitations).
 
 Read this before choosing Tachyon.
 
-**A merge briefly holds what it's merging fully in memory.** Writes are
-durable — they go to a write-ahead log and are replayed on startup — and
-once a memtable crosses `--max-memtable-docs`/`--max-memtable-bytes` it is
-flushed into an immutable, mmap'd on-disk segment: postings, columns, and
-document values are all read lazily and decoded only for what a query
-actually touches, which is what keeps memory bounded by how much of the
-corpus is hot rather than by corpus size. A query fans out across the
-memtable plus every committed segment, so segment count on its own drives
-latency up over time; once a collection holds more than
-`--merge-trigger-segments` (default 8), the smallest `--merge-fan-in`
-(default 4) are folded into one right after the flush that crossed that
-line. The trade: a merge rebuilds its input through a scratch memtable
-before re-encoding it, so it briefly holds everything being merged decoded
-at once — measured peak RSS during a 1M-doc run was ~1.5 GiB captured
-mid-merge, settling to ~49 MiB once indexing (including that merge)
-finished. Real, worth accounting for when tuning `--merge-fan-in` on a
-memory-constrained deployment, but momentary, not sustained. A direct
-merge of the already-encoded structures, avoiding the scratch memtable
-entirely, is the natural follow-up if this proves to matter in practice.
+**A merge still costs a stop-the-world pause on the collection's write
+lock, shrunk but not eliminated.** Writes are durable — they go to a
+write-ahead log and are replayed on startup — and once a memtable crosses
+`--max-memtable-docs`/`--max-memtable-bytes` it is flushed into an
+immutable, mmap'd on-disk segment: postings, columns, and document values
+are all read lazily and decoded only for what a query actually touches,
+which is what keeps memory bounded by how much of the corpus is hot rather
+than by corpus size. A query fans out across the memtable plus every
+committed segment, so segment count on its own drives latency up over time;
+once a collection holds more than `--merge-trigger-segments` (default 8),
+the smallest `--merge-fan-in` (default 4) are folded into one right after
+the flush that crossed that line, via a streaming k-way merge of the
+victims' already-encoded term dictionaries, postings, columns, and doc
+stores — no document is ever re-parsed or re-tokenized, and nothing beyond
+one term's or one field's worth of data is held in memory at a time. That
+made the biggest cost — a merge holding everything it was folding together
+decoded at once — go away: measured on a 1M-document, four-segment merge,
+each merge's own RSS delta averaged ~93 MiB and peaked at ~110 MiB, and a
+5M-document run's overall peak RSS fell from 5.2 GiB to 1.5 GiB. What's
+left is that the merge still runs synchronously under the write lock, so
+every search stalls for its duration — the streaming rewrite shrank that
+stall (a 1M-document flush-under-load run's worst-case concurrent search
+latency fell from 3.7 s to 1.9 s) but did not remove it, since running a
+merge off the lock entirely is a separate project this one didn't attempt.
 
 **Broad queries no longer visit every match unconditionally.** A block-level
 score bound (true block-max WAND, `.post`'s v3 format) now skips whole

--- a/crates/tachyon-bench/src/main.rs
+++ b/crates/tachyon-bench/src/main.rs
@@ -104,6 +104,37 @@ struct Args {
     /// How long `--concurrency` hammers the shared collection.
     #[arg(long, default_value_t = 10)]
     concurrency_duration_secs: u64,
+
+    /// Attempt a merge once a collection holds more than this many committed
+    /// segments — see `EngineConfig::merge_trigger_segments`. Applies to the
+    /// main Indexing/Search section and `--flush-scenario`; the default
+    /// matches `EngineConfig::default()` so omitting this flag changes
+    /// nothing about existing runs.
+    #[arg(long, default_value_t = 8)]
+    merge_trigger_segments: usize,
+
+    /// How many segments one merge folds together — see
+    /// `EngineConfig::merge_fan_in`.
+    #[arg(long, default_value_t = 4)]
+    merge_fan_in: usize,
+
+    /// Also run a merge scenario: index into a collection with auto-merge
+    /// disabled until several segments have accumulated, then explicitly
+    /// call `Collection::merge()` in a loop, reporting each merge's own wall
+    /// time and RSS delta — the number the streaming merge rewrite exists to
+    /// shrink, isolated from indexing and query traffic so it isn't averaged
+    /// away against everything else a full run does.
+    #[arg(long)]
+    merge_scenario: bool,
+
+    /// Documents per segment for `--merge-scenario`'s setup phase (i.e. its
+    /// own `--max-memtable-docs`), and the fan-in each explicit merge call
+    /// folds together.
+    #[arg(long, default_value_t = 100_000)]
+    merge_scenario_segment_docs: usize,
+
+    #[arg(long, default_value_t = 4)]
+    merge_scenario_fan_in: usize,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -121,7 +152,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Unbounded by default: the whole corpus stays in one memtable so this
     // measures the index, not the flush policy. Override with
     // `--max-memtable-docs` to measure against on-disk segments instead.
-    let config = config.with_max_memtable_docs(args.max_memtable_docs);
+    let config = config
+        .with_max_memtable_docs(args.max_memtable_docs)
+        .with_merge_trigger_segments(args.merge_trigger_segments)
+        .with_merge_fan_in(args.merge_fan_in);
 
     println!("Tachyon benchmark");
     println!("  documents   {}", args.documents);
@@ -246,6 +280,105 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if args.concurrency > 0 {
         run_concurrency_scenario(&args)?;
     }
+
+    if args.merge_scenario {
+        run_merge_scenario(&args)?;
+    }
+
+    Ok(())
+}
+
+/// Index enough documents to accumulate several on-disk segments with
+/// auto-merge disabled, then call `Collection::merge()` explicitly, once per
+/// `--merge-scenario-fan-in` segments, reporting each call's own wall time
+/// and RSS delta. Isolates the merge path's cost from indexing throughput
+/// and query latency, which the main run's aggregate numbers average it into.
+fn run_merge_scenario(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
+    let segments = args.documents.div_ceil(args.merge_scenario_segment_docs).max(2);
+    println!("Merge scenario");
+    println!("  segments                {segments}");
+    println!("  docs/segment            {}", args.merge_scenario_segment_docs);
+    println!("  merge fan-in            {}", args.merge_scenario_fan_in);
+    println!();
+
+    let dir = tempfile::tempdir()?;
+    let layout = Layout::new(dir.path());
+    layout.initialize()?;
+    let config = EngineConfig::new(dir.path())
+        .with_sync_policy(SyncPolicy::Interval(Duration::from_millis(200)))
+        .with_max_memtable_docs(args.merge_scenario_segment_docs)
+        // Disabled during setup: every flush should produce its own
+        // segment, not have some folded together before the loop below
+        // gets to measure a merge call's cost in isolation.
+        .with_merge_trigger_segments(usize::MAX)
+        .with_merge_fan_in(args.merge_scenario_fan_in);
+
+    let collection = Collection::create(&layout, corpus::schema("products"), &config)?;
+
+    // One `flush()` call per segment, explicitly — rather than relying on
+    // `max_memtable_docs` to trip mid-batch, which it may not: a flush
+    // check that only runs once per `upsert_batch` call (not per document)
+    // would otherwise let one large batch land entirely in a single
+    // segment regardless of the threshold, defeating the "several separate
+    // segments" setup this scenario needs.
+    let mut rng = Rng::new(args.seed);
+    let mut indexed = 0usize;
+    for _ in 0..segments {
+        let mut this_segment = 0usize;
+        while this_segment < args.merge_scenario_segment_docs {
+            let this_batch = args.batch_size.min(args.merge_scenario_segment_docs - this_segment);
+            let batch: Vec<_> = (0..this_batch)
+                .map(|i| corpus::document(&mut rng, indexed + i, args.vocab_scale))
+                .collect();
+            let report = collection.upsert_batch(batch)?;
+            if report.num_failed > 0 {
+                return Err(format!("{} documents failed to index", report.num_failed).into());
+            }
+            indexed += this_batch;
+            this_segment += this_batch;
+        }
+        collection.flush()?;
+    }
+    collection.sync()?;
+    println!("  segments after setup    {}", collection.stats().num_segments);
+    println!();
+
+    let mut merge_times_ms = Vec::new();
+    let mut rss_deltas = Vec::new();
+    loop {
+        let rss_before = current_rss_bytes();
+        let started = Instant::now();
+        let merged = collection.merge()?;
+        let elapsed = started.elapsed();
+        if !merged {
+            break;
+        }
+        merge_times_ms.push(elapsed.as_secs_f64() * 1000.0);
+        if let (Some(before), Some(after)) = (rss_before, current_rss_bytes()) {
+            rss_deltas.push(after as i64 - before as i64);
+        }
+    }
+
+    if merge_times_ms.is_empty() {
+        println!("  no merges ran — need at least `merge_fan_in` segments to fold together");
+        println!();
+        return Ok(());
+    }
+
+    let mean_ms = merge_times_ms.iter().sum::<f64>() / merge_times_ms.len() as f64;
+    let max_ms = merge_times_ms.iter().cloned().fold(0.0, f64::max);
+    println!("  merges run              {}", merge_times_ms.len());
+    println!("  mean merge time         {mean_ms:.1} ms");
+    println!("  max merge time          {max_ms:.1} ms");
+    if !rss_deltas.is_empty() {
+        let mean_delta = rss_deltas.iter().sum::<i64>() as f64 / rss_deltas.len() as f64;
+        let max_delta = rss_deltas.iter().cloned().max().unwrap_or(0);
+        println!("  mean RSS delta/merge    {}", human_bytes_signed(mean_delta as i64));
+        println!("  max RSS delta/merge     {}", human_bytes_signed(max_delta));
+    }
+    println!("  segments after merging  {}", collection.stats().num_segments);
+    println!("  rss (peak)              {}", human_bytes(peak_rss_bytes()));
+    println!();
 
     Ok(())
 }
@@ -541,4 +674,14 @@ fn human_bytes(bytes: usize) -> String {
         unit += 1;
     }
     format!("{value:.1} {}", UNITS[unit])
+}
+
+/// Same as [`human_bytes`], but for a signed delta — `current_rss_bytes()`
+/// can fall as well as rise between two samples.
+fn human_bytes_signed(bytes: i64) -> String {
+    if bytes < 0 {
+        format!("-{}", human_bytes(bytes.unsigned_abs() as usize))
+    } else {
+        format!("+{}", human_bytes(bytes as usize))
+    }
 }

--- a/crates/tachyon-engine/src/collection.rs
+++ b/crates/tachyon-engine/src/collection.rs
@@ -16,6 +16,9 @@
 //! order. Because doc ids are assigned sequentially from `state.next_doc_id`,
 //! replay reconstructs exactly the ids the crashed process had assigned.
 
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -25,14 +28,17 @@ use serde_json::Value as Json;
 use utoipa::ToSchema;
 
 use tachyon_core::{CollectionSchema, DocId, Error, ParsedDocument, Result};
-use tachyon_index::{encode, IndexSource, MemTable, SegmentFilePaths, SegmentReader};
+use tachyon_index::{
+    encode_streaming, merge_segments, IndexSource, MemTable, MergeInput, SegmentFilePaths,
+    SegmentReader,
+};
 use tachyon_query::{
     compute_facets, execute, suggest, Hit, SearchContext, SearchParams, SearchRequest,
     SearchResponse, SuggestParams, SuggestRequest, SuggestResponse,
 };
 use tachyon_storage::layout::sync_dir;
 use tachyon_storage::{
-    meta, wal, write_atomic, CollectionState, Layout, SegmentRef, Wal, WalRecord, WalRecordRef,
+    meta, wal, CollectionState, Layout, SegmentRef, Wal, WalRecord, WalRecordRef,
 };
 
 use crate::config::EngineConfig;
@@ -46,6 +52,99 @@ fn segment_file_paths(layout: &Layout, name: &str, id: u64) -> SegmentFilePaths 
         post: layout.segment_file(name, id, "post"),
         col: layout.segment_file(name, id, "col"),
         doc: layout.segment_file(name, id, "doc"),
+    }
+}
+
+/// `.tmp`-suffixed sibling of a segment file path, used while its bytes are
+/// still streaming to disk. Distinct from `write_atomic`'s own `.tmp`
+/// convention (which replaces the extension, fine for one file written and
+/// renamed at a time) because [`SegmentFiles`] has all five of one segment's
+/// files open and being streamed into at once — replacing the extension
+/// would collide every one of them on the same `<id>.tmp` path.
+fn segment_tmp_path(path: &Path) -> PathBuf {
+    let mut s = path.as_os_str().to_owned();
+    s.push(".tmp");
+    PathBuf::from(s)
+}
+
+/// Buffer size for each of the five open files' `BufWriter`. `encode_streaming`
+/// and `merge_segments` write in small increments — a `u32` or `u64` field at
+/// a time — so wrapping the raw `File` matters a great deal here: without it,
+/// every one of those tiny writes is its own `write(2)` syscall, which turned
+/// out to cost over an order of magnitude of indexing throughput when this
+/// was benchmarked unbuffered. 256 KiB comfortably holds even a wide term's
+/// or a large document's worth of writes before it needs to flush.
+const SEGMENT_WRITE_BUF_SIZE: usize = 256 * 1024;
+
+/// The five open files one segment's bytes stream into — the same durability
+/// shape `write_atomic` gives a single file (write to a temp sibling, fsync,
+/// rename, fsync the directory), just committed as one group of five rather
+/// than one file at a time, since [`tachyon_index::encode_streaming`] and
+/// [`tachyon_index::merge_segments`] write across all five in a single pass
+/// rather than producing one finished blob per file.
+struct SegmentFiles {
+    terms: BufWriter<File>,
+    ids: BufWriter<File>,
+    post: BufWriter<File>,
+    col: BufWriter<File>,
+    doc: BufWriter<File>,
+    tmp: SegmentFilePaths,
+    dest: SegmentFilePaths,
+}
+
+impl SegmentFiles {
+    fn create(paths: &SegmentFilePaths) -> Result<SegmentFiles> {
+        let parent = paths
+            .terms
+            .parent()
+            .ok_or_else(|| Error::internal("segment path has no parent directory"))?;
+        std::fs::create_dir_all(parent)?;
+        let tmp = SegmentFilePaths {
+            terms: segment_tmp_path(&paths.terms),
+            ids: segment_tmp_path(&paths.ids),
+            post: segment_tmp_path(&paths.post),
+            col: segment_tmp_path(&paths.col),
+            doc: segment_tmp_path(&paths.doc),
+        };
+        let buffered = |path: &Path| -> Result<BufWriter<File>> {
+            Ok(BufWriter::with_capacity(SEGMENT_WRITE_BUF_SIZE, File::create(path)?))
+        };
+        Ok(SegmentFiles {
+            terms: buffered(&tmp.terms)?,
+            ids: buffered(&tmp.ids)?,
+            post: buffered(&tmp.post)?,
+            col: buffered(&tmp.col)?,
+            doc: buffered(&tmp.doc)?,
+            tmp,
+            dest: paths.clone(),
+        })
+    }
+
+    /// Flush each `BufWriter`'s remaining bytes, fsync every underlying
+    /// file, rename each into place, then fsync the directory — the commit
+    /// point: a crash before the renames leaves the previous state intact
+    /// and these temp files orphaned but harmless, since nothing outside
+    /// `state.json` ever names a segment id.
+    fn commit(self, segments_dir: &Path) -> Result<()> {
+        fn finish(mut w: BufWriter<File>) -> Result<()> {
+            w.flush()?;
+            w.into_inner()
+                .map_err(|e| Error::internal(format!("flushing segment file: {e}")))?
+                .sync_all()?;
+            Ok(())
+        }
+        finish(self.terms)?;
+        finish(self.ids)?;
+        finish(self.post)?;
+        finish(self.col)?;
+        finish(self.doc)?;
+        std::fs::rename(&self.tmp.terms, &self.dest.terms)?;
+        std::fs::rename(&self.tmp.ids, &self.dest.ids)?;
+        std::fs::rename(&self.tmp.post, &self.dest.post)?;
+        std::fs::rename(&self.tmp.col, &self.dest.col)?;
+        std::fs::rename(&self.tmp.doc, &self.dest.doc)?;
+        sync_dir(segments_dir)?;
+        Ok(())
     }
 }
 
@@ -447,15 +546,18 @@ impl Collection {
         }
 
         let segment_id = inner.state.next_segment_id;
-        let encoded = encode(&inner.memtable, schema)?;
         let paths = segment_file_paths(layout, &schema.name, segment_id);
-
-        write_atomic(&paths.terms, &encoded.terms)?;
-        write_atomic(&paths.ids, &encoded.ids)?;
-        write_atomic(&paths.post, &encoded.post)?;
-        write_atomic(&paths.col, &encoded.col)?;
-        write_atomic(&paths.doc, &encoded.doc)?;
-        sync_dir(&layout.segments_dir(&schema.name))?;
+        let mut files = SegmentFiles::create(&paths)?;
+        encode_streaming(
+            &inner.memtable,
+            schema,
+            &mut files.terms,
+            &mut files.ids,
+            &mut files.post,
+            &mut files.col,
+            &mut files.doc,
+        )?;
+        files.commit(&layout.segments_dir(&schema.name))?;
 
         let new_wal_generation = inner.state.wal_generation + 1;
         let new_wal =
@@ -516,18 +618,18 @@ impl Collection {
     /// A merge renumbers rather than preserves doc ids. `SegmentRef`'s
     /// range is fixed for a segment's life and doc ids are never reused, so
     /// preserving the originals across a merge would mean building a new
-    /// on-disk segment out of two *already-encoded* ones — a from-scratch
-    /// k-way merge of sorted term dictionaries and postings, with nothing
-    /// in this codebase to build that on top of. Renumbering instead means
-    /// a merge is just: fetch each live document's source, run it through
-    /// the exact same `ParsedDocument::parse` + `MemTable::insert` path a
-    /// fresh write already takes, and call the existing `encode` on the
-    /// result — the entire pipeline is reused unchanged, and the only new
-    /// code here is picking victims and updating the commit state. The
-    /// cost is re-tokenizing every merged document; that's fine because a
-    /// merge is infrequent background-ish work, not a query-path cost.
-    /// Doc ids retired this way are simply never claimed again — no
-    /// segment or memtable ever covers that range afterward — except that
+    /// on-disk segment out of two *already-encoded* ones — which, since
+    /// `tachyon_index::merge_segments`, is exactly what this does: a
+    /// streaming k-way merge of the victims' term dictionaries, postings,
+    /// columns, and doc stores, straight into the output segment's five
+    /// files. Renumbering is still required (the union of two segments'
+    /// doc id ranges is never itself contiguous once dead documents drop
+    /// out), so this still picks victims and remaps every surviving id, but
+    /// nothing here re-parses a document's source or re-tokenizes its text
+    /// — that work already happened once, when each victim was first
+    /// flushed, and a merge's job is to copy it forward, not redo it. Doc
+    /// ids retired this way are simply never claimed again — no segment or
+    /// memtable ever covers that range afterward — except that
     /// `inner.deleted` can hold stale tombstones for them, which this
     /// prunes explicitly.
     ///
@@ -558,9 +660,6 @@ impl Collection {
         let victim_readers: Vec<Arc<SegmentReader>> =
             victims.iter().map(|&i| Arc::clone(&inner.segments[i])).collect();
 
-        // Rebuild: every live, non-tombstoned document across the victims,
-        // re-validated and re-tokenized exactly like a fresh insert.
-        //
         // The range this claims must start from the *active* memtable's own
         // `next_doc_id()`, not `inner.state.next_doc_id` — the two agree
         // when merging runs right after a flush (the common case: the fresh
@@ -572,25 +671,21 @@ impl Collection {
         // range is claimed, the memtable is told to skip over it too — see
         // that call's comment for why.
         let merge_base = inner.memtable.next_doc_id();
-        let mut merged = MemTable::new(merge_base, schema);
-        for reader in &victim_readers {
-            for doc_id in reader.min_doc_id()..reader.end_doc_id() {
-                if !reader.is_live(doc_id) || inner.deleted.contains(doc_id) {
-                    continue;
-                }
-                let Some(source) = reader.get(doc_id) else { continue };
-                let parsed = ParsedDocument::parse(source, schema).map_err(|e| {
-                    Error::corruption(format!(
-                        "segment doc {doc_id} failed to re-parse during merge: {e}"
-                    ))
-                })?;
-                merged.insert(parsed);
-            }
-        }
-        // How many ids `merged` actually claimed out of `merge_base`'s range
-        // — 0 if every victim document turned out to be dead, same as
-        // `wrote_segment` below computes it.
-        let claimed = merged.next_doc_id() - merge_base;
+
+        // Each victim's own surviving doc ids: its presence bitmap (already
+        // excludes anything that was a hole when it was flushed) minus
+        // whatever the collection has tombstoned since. `merge_segments`
+        // remaps every id in here to a fresh, dense, monotone range starting
+        // at `merge_base` — see its own doc comment for exactly how.
+        let merge_inputs: Vec<MergeInput> = victim_readers
+            .iter()
+            .map(|reader| {
+                let mut live = reader.presence().clone();
+                live -= &inner.deleted;
+                MergeInput { reader: reader.as_ref(), live }
+            })
+            .collect();
+        let claimed: DocId = merge_inputs.iter().map(|input| input.live.len() as DocId).sum();
 
         let mut new_state = inner.state.clone();
 
@@ -613,22 +708,27 @@ impl Collection {
 
         // Every document merged away was dead — nothing to write, the
         // victims simply disappear with no replacement.
-        let wrote_segment = merged.next_doc_id() > merged.base();
+        let wrote_segment = claimed > 0;
         let mut new_reader = None;
         if wrote_segment {
             let segment_id = new_state.next_segment_id;
-            let encoded = encode(&merged, schema)?;
             let paths = segment_file_paths(layout, &schema.name, segment_id);
-
-            write_atomic(&paths.terms, &encoded.terms)?;
-            write_atomic(&paths.ids, &encoded.ids)?;
-            write_atomic(&paths.post, &encoded.post)?;
-            write_atomic(&paths.col, &encoded.col)?;
-            write_atomic(&paths.doc, &encoded.doc)?;
-            sync_dir(&layout.segments_dir(&schema.name))?;
+            let mut files = SegmentFiles::create(&paths)?;
+            let stats = merge_segments(
+                &merge_inputs,
+                schema,
+                merge_base,
+                &mut files.terms,
+                &mut files.ids,
+                &mut files.post,
+                &mut files.col,
+                &mut files.doc,
+            )?;
+            files.commit(&layout.segments_dir(&schema.name))?;
+            debug_assert_eq!(stats.doc_count as DocId, claimed);
 
             new_state.next_segment_id += 1;
-            new_state.next_doc_id = merged.next_doc_id();
+            new_state.next_doc_id = merge_base + claimed;
             // `victims[0]` is the smallest victim index, which — now that
             // every victim has been removed — equals the number of
             // untouched segments that came before it. Inserting there puts
@@ -639,9 +739,9 @@ impl Collection {
                 victims[0],
                 SegmentRef {
                     id: segment_id,
-                    doc_count: merged.len() as u32,
-                    min_doc_id: merged.base(),
-                    max_doc_id: merged.next_doc_id() - 1,
+                    doc_count: stats.doc_count as u32,
+                    min_doc_id: merge_base,
+                    max_doc_id: merge_base + claimed - 1,
                 },
             );
             new_reader = Some(Arc::new(SegmentReader::open(&paths, schema)?));

--- a/crates/tachyon-index/src/lib.rs
+++ b/crates/tachyon-index/src/lib.rs
@@ -17,6 +17,9 @@ pub use cursor::{MergeCursor, PostingCursor};
 pub use fuzzy::{distance_within, FuzzyMatcher};
 pub use inverted::{DocPosting, FieldPostings, InvertedIndex};
 pub use memtable::{MemTable, StoredDoc};
-pub use segment::{encode, EncodedSegment, SegmentFilePaths, SegmentReader};
+pub use segment::{
+    encode, encode_streaming, merge_segments, EncodedSegment, MergeInput, MergeStats,
+    SegmentFilePaths, SegmentReader,
+};
 pub use source::IndexSource;
 pub use tokenizer::{tokenize, Token};

--- a/crates/tachyon-index/src/segment/codec.rs
+++ b/crates/tachyon-index/src/segment/codec.rs
@@ -1,14 +1,35 @@
-//! Segment byte codec, v2: encode a live view of a [`MemTable`] into five
-//! segment blobs, and decode them back — lazily. Nothing here holds a whole
-//! segment's postings, columns, or documents in memory at once; every decode
-//! function here takes the byte slice it needs and returns just the one
-//! term's postings, one field's column, or one document's value the caller
-//! asked for. `tachyon-engine`'s `SegmentReader` wraps these around an mmap'd
-//! file per blob and calls them per query.
+//! Segment byte codec, v4: stream a live view of a [`MemTable`] — or, via
+//! [`super::merge`], several already-encoded segments — into five segment
+//! blobs, and decode them back — lazily. Nothing here holds a whole segment's
+//! postings, columns, or documents in memory at once; every write function
+//! streams forward through an [`impl Write`](std::io::Write) sink, bounded by
+//! at most one term's, one field's, or one document's worth of scratch space
+//! at a time — never by corpus size. Every decode function takes the byte
+//! slice it needs and returns just the one term's postings, one field's
+//! column, or one document's value the caller asked for. `tachyon-engine`'s
+//! `SegmentReader` wraps these around an mmap'd file per blob and calls them
+//! per query.
 //!
-//! No filesystem access here — writing the bytes to disk and committing them
-//! is `tachyon-engine`'s job, per `tachyon-storage`'s "segment *contents* are
-//! the index crate's business, segment *lifecycle* is the engine's" split.
+//! No filesystem access here — opening the destination files, writing them
+//! to disk, and committing them into `state.json` is `tachyon-engine`'s job,
+//! per `tachyon-storage`'s "segment *contents* are the index crate's
+//! business, segment *lifecycle* is the engine's" split.
+//!
+//! # Footer layout
+//!
+//! `.post`, `.col`, and `.doc` all follow the same shape: a 12-byte header,
+//! then payload data written forward as it's produced, then a footer (the
+//! directory a query needs to locate anything — an offset table, a column
+//! directory, a doc-store section table) written last, once its contents are
+//! finally known, and a trailing 8-byte absolute file offset pointing at
+//! where that footer begins. A reader with the whole file mmap'd checks the
+//! header, reads the last 8 bytes to find the footer, and reads the footer
+//! from there — no different in cost from a front-loaded directory, since
+//! mmap makes every byte in the file equally cheap to reach. What it buys is
+//! a writer that never needs to know its own directory's size or contents
+//! before starting to stream payload bytes. `.terms` and `.ids` need no such
+//! footer: both are `fst::Map`s, and `fst::MapBuilder` already streams
+//! directly into a [`Write`](std::io::Write) sink in sorted-key order.
 //!
 //! # Holes
 //!
@@ -20,6 +41,7 @@
 //! policy leaves behind.
 
 use std::collections::HashMap;
+use std::io::Write;
 
 use roaring::RoaringBitmap;
 use serde_json::Value as Json;
@@ -31,12 +53,18 @@ use crate::inverted::DocPosting;
 use crate::memtable::MemTable;
 
 use super::format::{
-    bytes_at, f64_at, i64_at, u32_at, u8_at, write_bytes, write_f64, write_header, write_i64,
-    write_str, write_u32, write_u64, write_u8, Cursor, COL_MAGIC, DOC_MAGIC, HEADER_LEN, IDS_MAGIC,
-    POST_MAGIC, TERMS_MAGIC,
+    bytes_at, f64_at, i64_at, u32_at, u64_at, u8_at, write_bytes, write_f64, write_header,
+    write_i64, write_str, write_u32, write_u64, write_u8, CountingWriter, Cursor, COL_MAGIC,
+    DOC_MAGIC, FOOTER_POINTER_LEN, HEADER_LEN, IDS_MAGIC, POST_MAGIC, TERMS_MAGIC,
 };
 
 /// The five byte blobs one segment is made of, ready to be written to disk.
+/// Exists mainly so `codec`'s own tests (and a couple of tests elsewhere in
+/// this crate that don't need real files) can call [`encode`] and get
+/// something they can slice into directly — `tachyon-engine`'s real flush
+/// and merge paths stream straight into files via
+/// [`encode_streaming`]/[`super::merge::merge_segments`] instead, without
+/// ever materializing a segment's bytes in one buffer.
 pub struct EncodedSegment {
     pub terms: Vec<u8>,
     pub ids: Vec<u8>,
@@ -45,25 +73,43 @@ pub struct EncodedSegment {
     pub doc: Vec<u8>,
 }
 
-/// Encode every live document in `memtable` into segment bytes.
+/// Encode every live document in `memtable` into segment bytes, in memory.
+/// A thin convenience wrapper around [`encode_streaming`] for callers (tests,
+/// mostly) that want an owned blob rather than to stream into files — see
+/// [`EncodedSegment`]'s doc comment.
 pub fn encode(memtable: &MemTable, schema: &CollectionSchema) -> Result<EncodedSegment> {
-    let live: RoaringBitmap = memtable.iter().map(|(id, _)| id).collect();
-
-    let (terms, post) = encode_postings(memtable, &live, schema)?;
-    let ids = encode_ids(memtable)?;
-    let col = encode_columns(memtable, &live, schema);
-    let doc = encode_docs(memtable, schema);
-
+    let mut terms = Vec::new();
+    let mut ids = Vec::new();
+    let mut post = Vec::new();
+    let mut col = Vec::new();
+    let mut doc = Vec::new();
+    encode_streaming(memtable, schema, &mut terms, &mut ids, &mut post, &mut col, &mut doc)?;
     Ok(EncodedSegment { terms, ids, post, col, doc })
 }
 
-/// Wrap the payload of an `fst::Map` (built in memory) with the standard
-/// segment header, so every file — FST-backed or not — starts the same way.
-fn wrap_fst(magic: &[u8; 8], fst_bytes: Vec<u8>) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(HEADER_LEN + fst_bytes.len());
-    write_header(&mut buf, magic);
-    buf.extend_from_slice(&fst_bytes);
-    buf
+/// Stream every live document in `memtable` into the five sinks, in bounded
+/// memory: `terms_w`/`ids_w` grow with the FST as `fst::MapBuilder` writes to
+/// them, `post_w` never holds more than one term-field's postings at a time,
+/// `col_w` never holds more than one field's column at a time, and `doc_w`'s
+/// bounded scratch (`field_lengths`/`values_dir`/`source_dir`) is sized by
+/// document count and field count, not by document content. Nothing here
+/// scales with total corpus text or position count.
+pub fn encode_streaming(
+    memtable: &MemTable,
+    schema: &CollectionSchema,
+    terms_w: impl Write,
+    ids_w: impl Write,
+    post_w: impl Write,
+    col_w: impl Write,
+    doc_w: impl Write,
+) -> Result<()> {
+    let live: RoaringBitmap = memtable.iter().map(|(id, _)| id).collect();
+
+    encode_postings_streaming(memtable, &live, schema, terms_w, post_w)?;
+    encode_ids_streaming(memtable, ids_w)?;
+    encode_columns_streaming(memtable, &live, schema, col_w)?;
+    encode_docs_streaming(memtable, schema, doc_w)?;
+    Ok(())
 }
 
 /// Validate a header and return the byte offset where the payload after it
@@ -75,29 +121,57 @@ pub fn validate_header(bytes: &[u8], magic: &[u8; 8], what: &'static str) -> Res
     Ok(cur.position())
 }
 
-// --- ids -------------------------------------------------------------------
+/// The absolute file offset the trailing 8-byte footer pointer names, for a
+/// footer-based file (`.post`/`.col`/`.doc`). `what` labels corruption errors.
+fn read_footer_start(bytes: &[u8], what: &'static str) -> Result<usize> {
+    if bytes.len() < HEADER_LEN + FOOTER_POINTER_LEN {
+        return Err(Error::corruption(format!("{what}: truncated or malformed")));
+    }
+    let footer_start = u64_at(bytes, bytes.len() - FOOTER_POINTER_LEN, what)? as usize;
+    if footer_start < HEADER_LEN || footer_start > bytes.len() - FOOTER_POINTER_LEN {
+        return Err(Error::corruption(format!("{what}: footer pointer out of range")));
+    }
+    Ok(footer_start)
+}
+
+// --- ids ---------------------------------------------------------------
 
 /// `id -> doc_id`, an `fst::Map` exactly like `.terms` — sorted, mmap'd,
 /// nothing resident but the offset of the file itself. Replaces holding a
-/// `HashMap<Box<str>, DocId>` for the whole segment.
-fn encode_ids(memtable: &MemTable) -> Result<Vec<u8>> {
+/// `HashMap<Box<str>, DocId>` for the whole segment. The `(id, doc_id)` pairs
+/// themselves are held as a `Vec` to be sorted before insertion (`fst`
+/// requires ascending-key insertion) — bounded by total id-string bytes,
+/// which is small next to postings or document text and not worth streaming
+/// around.
+fn encode_ids_streaming(memtable: &MemTable, ids_w: impl Write) -> Result<()> {
     let mut pairs: Vec<(&str, DocId)> =
         memtable.iter().map(|(doc_id, doc)| (doc.id.as_str(), doc_id)).collect();
     pairs.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
-
-    let mut builder = fst::MapBuilder::memory();
-    for (id, doc_id) in &pairs {
-        builder
-            .insert(id, *doc_id as u64)
-            .map_err(|e| Error::internal(format!("building segment id index: {e}")))?;
-    }
-    let fst_bytes = builder
-        .into_inner()
-        .map_err(|e| Error::internal(format!("building segment id index: {e}")))?;
-    Ok(wrap_fst(IDS_MAGIC, fst_bytes))
+    write_fst(ids_w, IDS_MAGIC, pairs.into_iter().map(|(id, doc_id)| (id, doc_id as u64)))
 }
 
-// --- postings + terms --------------------------------------------------
+/// Write a header followed by an `fst::Map` streamed directly from a sorted
+/// `(key, value)` iterator — used for both `.ids` (id order, pairs already
+/// buffered and sorted by the caller) and `.terms` (dictionary order, driven
+/// term-by-term by the postings writer so the map and the postings it points
+/// into are built in the same pass).
+pub(crate) fn write_fst<'a>(
+    mut w: impl Write,
+    magic: &[u8; 8],
+    pairs: impl Iterator<Item = (&'a str, u64)>,
+) -> Result<()> {
+    write_header(&mut w, magic)?;
+    let mut builder = fst::MapBuilder::new(w)
+        .map_err(|e| Error::internal(format!("building segment id/term index: {e}")))?;
+    for (key, value) in pairs {
+        builder
+            .insert(key, value)
+            .map_err(|e| Error::internal(format!("building segment id/term index: {e}")))?;
+    }
+    builder.finish().map_err(|e| Error::internal(format!("building segment id/term index: {e}")))
+}
+
+// --- postings + terms ----------------------------------------------------
 
 /// Fixed number of docs per posting block: small enough that a block's
 /// `max_tf` tracks the true local maximum closely (a tight bound is what
@@ -106,24 +180,29 @@ fn encode_ids(memtable: &MemTable) -> Result<Vec<u8>> {
 /// 20 bytes ≈ 1.5 KB.
 pub(crate) const POSTING_BLOCK_SIZE: usize = 128;
 
+/// Byte width of one [`BlockMeta`] on disk: `last_doc_id`(4) + `max_tf`(4) +
+/// `offset`(8) + `length`(4).
+const BLOCK_META_LEN: u64 = 20;
+
 /// Fixed-width per-block skip metadata: lets a query decide whether to skip
 /// a block, or jump straight to one, without decoding a single posting
-/// inside it. 20 bytes on disk.
+/// inside it. 20 bytes on disk. `offset` is always an absolute file offset,
+/// whether freshly computed by the streaming postings writer or rebased by
+/// [`decode_term_field_blocks`] when read back.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct BlockMeta {
     pub last_doc_id: DocId,
     pub max_tf: u32,
-    /// Absolute byte offset of this block's payload, into the same `.post`
-    /// byte slice `decode_term_field_blocks` was called with.
     pub offset: u64,
     pub length: u32,
 }
 
-fn write_block_meta(buf: &mut Vec<u8>, meta: &BlockMeta) {
-    write_u32(buf, meta.last_doc_id);
-    write_u32(buf, meta.max_tf);
-    write_u64(buf, meta.offset);
-    write_u32(buf, meta.length);
+pub(crate) fn write_block_meta(w: &mut impl Write, meta: &BlockMeta) -> Result<()> {
+    write_u32(w, meta.last_doc_id)?;
+    write_u32(w, meta.max_tf)?;
+    write_u64(w, meta.offset)?;
+    write_u32(w, meta.length)?;
+    Ok(())
 }
 
 fn read_block_meta(cur: &mut Cursor) -> Result<BlockMeta> {
@@ -134,11 +213,17 @@ fn read_block_meta(cur: &mut Cursor) -> Result<BlockMeta> {
     Ok(BlockMeta { last_doc_id, max_tf, offset, length })
 }
 
-fn encode_postings(
+/// Stream `.post` (postings, one term-field's blocks at a time) and `.terms`
+/// (the term dictionary, built alongside it) together, since a term is only
+/// worth writing to either once it's known to have at least one surviving
+/// posting after live-filtering.
+fn encode_postings_streaming(
     memtable: &MemTable,
     live: &RoaringBitmap,
     schema: &CollectionSchema,
-) -> Result<(Vec<u8>, Vec<u8>)> {
+    mut terms_w: impl Write,
+    post_w: impl Write,
+) -> Result<()> {
     let num_fields = schema.fields.len();
     let mut field_doc_count = vec![0u32; num_fields];
     let mut field_total_len = vec![0u64; num_fields];
@@ -151,13 +236,17 @@ fn encode_postings(
         }
     }
 
-    // Surviving terms, in the dictionary's existing sorted order, with dead
-    // postings filtered out and any term/field left empty by that dropped.
-    struct TermBlock<'a> {
-        term: &'a str,
-        fields: Vec<(FieldId, Vec<&'a DocPosting>)>,
-    }
-    let mut blocks: Vec<TermBlock> = Vec::new();
+    let mut post_w = CountingWriter::new(post_w);
+    write_header(&mut post_w, POST_MAGIC)?;
+
+    write_header(&mut terms_w, TERMS_MAGIC)?;
+    let mut terms_builder = fst::MapBuilder::new(terms_w)
+        .map_err(|e| Error::internal(format!("building segment term dictionary: {e}")))?;
+
+    // fst requires ascending-key insertion; the dictionary is already sorted.
+    let mut term_offsets: Vec<u64> = Vec::new();
+    let mut term_id: u64 = 0;
+
     for (term, fields) in memtable.index().iter() {
         let mut kept: Vec<(FieldId, Vec<&DocPosting>)> = Vec::new();
         for (field, postings) in fields {
@@ -167,88 +256,79 @@ fn encode_postings(
                 kept.push((*field, docs));
             }
         }
-        if !kept.is_empty() {
-            blocks.push(TermBlock { term, fields: kept });
+        if kept.is_empty() {
+            continue;
         }
-    }
 
-    // fst requires ascending-key insertion; the dictionary is already sorted.
-    let mut builder = fst::MapBuilder::memory();
-    for (term_id, block) in blocks.iter().enumerate() {
-        builder
-            .insert(block.term, term_id as u64)
+        term_offsets.push(post_w.pos());
+        terms_builder
+            .insert(term, term_id)
             .map_err(|e| Error::internal(format!("building segment term dictionary: {e}")))?;
-    }
-    let fst_bytes = builder
-        .into_inner()
-        .map_err(|e| Error::internal(format!("building segment term dictionary: {e}")))?;
-    let terms = wrap_fst(TERMS_MAGIC, fst_bytes);
+        term_id += 1;
 
-    // Postings data, term by term, with an offset table so any one term's
-    // block can be located and decoded without touching the others. Within a
-    // term, each field's postings are further chunked into fixed-size blocks
-    // with their own skip-metadata directory (`BlockMeta`) — see this file's
-    // module doc and `SEGMENT_FORMAT_VERSION`'s doc comment for the shape.
-    let mut data = Vec::new();
-    let mut offsets = Vec::with_capacity(blocks.len());
-    for block in &blocks {
-        offsets.push(data.len() as u64);
-        write_u32(&mut data, block.fields.len() as u32);
-        for (field, docs) in &block.fields {
-            write_u32(&mut data, *field as u32);
-            write_u32(&mut data, docs.len() as u32); // doc_freq: O(1) to read back
+        write_u32(&mut post_w, kept.len() as u32)?;
+        for (field, docs) in &kept {
+            write_u32(&mut post_w, *field as u32)?;
+            write_u32(&mut post_w, docs.len() as u32)?; // doc_freq: O(1) to read back
 
             let chunks: Vec<&[&DocPosting]> = docs.chunks(POSTING_BLOCK_SIZE).collect();
-            write_u32(&mut data, chunks.len() as u32);
+            write_u32(&mut post_w, chunks.len() as u32)?;
 
-            // Two-pass: build every block's payload bytes into a scratch
-            // buffer first, so each block's own offset (relative to where
-            // this field's payloads begin) is known before its directory
-            // entry is written — the directory precedes the payloads on
-            // disk, so a single forward pass can't know them yet.
+            // Two-pass within this one field's blocks, bounded by this one
+            // (term, field)'s postings — not the whole segment's: each
+            // block's own offset (relative to where this field's payloads
+            // begin) must be known before its directory entry is written,
+            // and the directory precedes the payloads on disk, so a single
+            // forward pass over just this scratch buffer can't know them yet.
             let mut payloads = Vec::new();
             let mut metas = Vec::with_capacity(chunks.len());
             for chunk in &chunks {
                 let start = payloads.len() as u64;
-                write_u32(&mut payloads, chunk.len() as u32);
+                write_u32(&mut payloads, chunk.len() as u32)?;
                 let mut max_tf = 0u32;
                 for posting in *chunk {
-                    write_u32(&mut payloads, posting.doc_id);
-                    write_u32(&mut payloads, posting.positions.len() as u32);
+                    write_u32(&mut payloads, posting.doc_id)?;
+                    write_u32(&mut payloads, posting.positions.len() as u32)?;
                     for &p in &posting.positions {
-                        write_u32(&mut payloads, p);
+                        write_u32(&mut payloads, p)?;
                     }
                     max_tf = max_tf.max(posting.positions.len() as u32);
                 }
                 metas.push(BlockMeta {
                     last_doc_id: chunk.last().expect("chunks() never yields an empty slice").doc_id,
                     max_tf,
-                    offset: start,
+                    offset: start, // relative to `payloads`; rebased to absolute below
                     length: (payloads.len() as u64 - start) as u32,
                 });
             }
 
+            let payload_base = post_w.pos() + metas.len() as u64 * BLOCK_META_LEN;
             for meta in &metas {
-                write_block_meta(&mut data, meta);
+                write_block_meta(
+                    &mut post_w,
+                    &BlockMeta { offset: payload_base + meta.offset, ..*meta },
+                )?;
             }
-            data.extend_from_slice(&payloads);
+            post_w.write_all(&payloads)?;
         }
     }
 
-    let mut post = Vec::new();
-    write_header(&mut post, POST_MAGIC);
-    write_u32(&mut post, num_fields as u32);
-    for f in 0..num_fields {
-        write_u32(&mut post, field_doc_count[f]);
-        write_u64(&mut post, field_total_len[f]);
-    }
-    write_u32(&mut post, blocks.len() as u32);
-    for off in &offsets {
-        write_u64(&mut post, *off);
-    }
-    post.extend_from_slice(&data);
+    terms_builder
+        .finish()
+        .map_err(|e| Error::internal(format!("finishing term dictionary: {e}")))?;
 
-    Ok((terms, post))
+    let footer_start = post_w.pos();
+    write_u32(&mut post_w, num_fields as u32)?;
+    for f in 0..num_fields {
+        write_u32(&mut post_w, field_doc_count[f])?;
+        write_u64(&mut post_w, field_total_len[f])?;
+    }
+    write_u32(&mut post_w, term_offsets.len() as u32)?;
+    for off in &term_offsets {
+        write_u64(&mut post_w, *off)?;
+    }
+    write_u64(&mut post_w, footer_start)?;
+    Ok(())
 }
 
 /// The small, eager part of `.post`: field stats and the offset table. O(num
@@ -256,14 +336,22 @@ fn encode_postings(
 pub(crate) struct PostHeader {
     pub field_doc_count: Vec<u32>,
     pub field_total_len: Vec<u64>,
-    /// Byte offset of term `i`'s block, relative to the start of the file.
+    /// Absolute byte offset of term `i`'s block.
     offsets: Vec<u64>,
+    /// Absolute offset the footer itself starts at — a term's block always
+    /// ends either at the next term's offset, or here for the last one.
+    footer_start: u64,
 }
 
 pub(crate) fn decode_post_header(bytes: &[u8]) -> Result<PostHeader> {
-    let mut cur = Cursor::new(bytes, "segment postings");
-    cur.read_header(POST_MAGIC)?;
+    let what = "segment postings";
+    {
+        let mut cur = Cursor::new(bytes, what);
+        cur.read_header(POST_MAGIC)?;
+    }
+    let footer_start = read_footer_start(bytes, what)?;
 
+    let mut cur = Cursor::new(&bytes[footer_start..bytes.len() - FOOTER_POINTER_LEN], what);
     let num_fields = cur.read_u32()? as usize;
     let mut field_doc_count = Vec::with_capacity(num_fields);
     let mut field_total_len = Vec::with_capacity(num_fields);
@@ -272,21 +360,13 @@ pub(crate) fn decode_post_header(bytes: &[u8]) -> Result<PostHeader> {
         field_total_len.push(cur.read_u64()?);
     }
 
-    // The offset table stores byte positions relative to the start of the
-    // *data* section, i.e. right after the table itself — read it straight,
-    // then add back where the data section begins so lookups are absolute
-    // offsets into the file.
     let num_terms = cur.read_u32()? as usize;
     let mut offsets = Vec::with_capacity(num_terms);
     for _ in 0..num_terms {
         offsets.push(cur.read_u64()?);
     }
-    let data_start = cur.position() as u64;
-    for off in &mut offsets {
-        *off += data_start;
-    }
 
-    Ok(PostHeader { field_doc_count, field_total_len, offsets })
+    Ok(PostHeader { field_doc_count, field_total_len, offsets, footer_start: footer_start as u64 })
 }
 
 const POST_BLOCK_WHAT: &str = "segment postings (term block)";
@@ -303,11 +383,17 @@ fn term_block_start(header: &PostHeader, term_id: u64) -> Result<usize> {
 fn term_block<'a>(bytes: &'a [u8], header: &PostHeader, term_id: u64) -> Result<&'a [u8]> {
     let start = term_block_start(header, term_id)?;
     let idx = term_id as usize;
-    let end =
-        if idx + 1 < header.offsets.len() { header.offsets[idx + 1] as usize } else { bytes.len() };
-    bytes
-        .get(start..end)
-        .ok_or_else(|| Error::corruption(format!("{POST_BLOCK_WHAT}: offset table out of range")))
+    let end = if idx + 1 < header.offsets.len() {
+        header.offsets[idx + 1] as usize
+    } else {
+        header.footer_start as usize
+    };
+    bytes.get(start..end).ok_or_else(|| {
+        Error::corruption(format!(
+            "{POST_BLOCK_WHAT}: offset table out of range (term_id={term_id} start={start} end={end} bytes.len()={} footer_start={} offsets.len()={})",
+            bytes.len(), header.footer_start, header.offsets.len()
+        ))
+    })
 }
 
 /// One (term, field)'s block directory: a doc-frequency count, read once, and
@@ -319,11 +405,9 @@ pub(crate) struct TermFieldBlocks {
 }
 
 /// Decode one (term, field)'s block directory: `doc_freq` and every block's
-/// `BlockMeta`, with `BlockMeta.offset` already turned into an absolute
-/// offset into `bytes` (the same convention `decode_post_header` uses for its
-/// own top-level term table, one level up). `None` if the term never occurs
-/// in this field. The production entry point for the postings walk — no
-/// posting is decoded here, only the directory that says where they live.
+/// `BlockMeta`, whose `offset` is already absolute. `None` if the term never
+/// occurs in this field. The production entry point for the postings walk —
+/// no posting is decoded here, only the directory that says where they live.
 pub(crate) fn decode_term_field_blocks(
     bytes: &[u8],
     header: &PostHeader,
@@ -331,7 +415,6 @@ pub(crate) fn decode_term_field_blocks(
     field: FieldId,
 ) -> Result<Option<TermFieldBlocks>> {
     let what = POST_BLOCK_WHAT;
-    let term_start = term_block_start(header, term_id)?;
     let block = term_block(bytes, header, term_id)?;
 
     let mut cur = Cursor::new(block, what);
@@ -342,9 +425,16 @@ pub(crate) fn decode_term_field_blocks(
         let num_blocks = cur.read_u32()? as usize;
 
         // Every block's metadata is fixed-width and read up front regardless
-        // of whether this is the field being asked about — for a field
-        // that isn't, `BlockMeta.length` is exactly what's needed to skip
-        // its payloads without decoding a single doc inside them.
+        // of whether this is the field being asked about — for a field that
+        // isn't, `BlockMeta.length` is exactly what's needed to skip its
+        // payload bytes (which, unlike the metadata, this cursor never
+        // otherwise touches) without decoding a single doc inside them.
+        // Skipping matters even though `BlockMeta.offset` is already an
+        // absolute file offset (nothing here needs rebasing, unlike the pre-
+        // v4 format): this cursor is walking a *sequential* layout — this
+        // field's payloads sit directly between its own directory and the
+        // next field's — so failing to skip past them would leave the
+        // cursor reading the next field's header starting mid-payload.
         let mut blocks = Vec::with_capacity(num_blocks);
         let mut payload_len: u64 = 0;
         for _ in 0..num_blocks {
@@ -356,11 +446,6 @@ pub(crate) fn decode_term_field_blocks(
         if this_field != field {
             cur.skip(payload_len as usize)?;
             continue;
-        }
-
-        let payloads_start = (term_start + cur.position()) as u64;
-        for meta in &mut blocks {
-            meta.offset += payloads_start;
         }
         return Ok(Some(TermFieldBlocks { doc_freq, blocks }));
     }
@@ -447,41 +532,59 @@ pub(crate) fn decode_term_field_doc_ids(
 
 // --- columns -----------------------------------------------------------
 
-const FIELD_TAG_NONE: u8 = 0;
-const FIELD_TAG_NUMERIC: u8 = 1;
-const FIELD_TAG_KEYWORD: u8 = 2;
-const NUMKEY_TAG_INT: u8 = 0;
-const NUMKEY_TAG_FLOAT: u8 = 1;
+pub(crate) const FIELD_TAG_NONE: u8 = 0;
+pub(crate) const FIELD_TAG_NUMERIC: u8 = 1;
+pub(crate) const FIELD_TAG_KEYWORD: u8 = 2;
+pub(crate) const NUMKEY_TAG_INT: u8 = 0;
+pub(crate) const NUMKEY_TAG_FLOAT: u8 = 1;
 
-fn encode_columns(memtable: &MemTable, live: &RoaringBitmap, schema: &CollectionSchema) -> Vec<u8> {
+/// Stream `.col`: one field's column at a time, in field-id order, with the
+/// per-field directory (tag, offset, length) recorded as each field's data
+/// is written and emitted as a footer once every field has been visited.
+///
+/// Keyword values are written in **sorted order** — not the `HashMap`
+/// iteration order a naive per-field walk would produce. That determinism
+/// isn't just tidiness: two encodes of the same live document set must
+/// produce byte-identical `.col` bytes for the streaming merge path's
+/// equivalence tests to be meaningful, and `HashMap`'s randomized iteration
+/// order means the pre-v4 encoder didn't actually have that property even
+/// though nothing depended on it before now.
+fn encode_columns_streaming(
+    memtable: &MemTable,
+    live: &RoaringBitmap,
+    schema: &CollectionSchema,
+    col_w: impl Write,
+) -> Result<()> {
+    let mut col_w = CountingWriter::new(col_w);
+    write_header(&mut col_w, COL_MAGIC)?;
+
     let columns = memtable.columns();
-    let mut data = Vec::new();
-    let mut directory: Vec<(u8, u32, u32)> = Vec::with_capacity(schema.fields.len());
+    let num_fields = schema.fields.len();
+    let mut directory: Vec<(u8, u64, u64)> = Vec::with_capacity(num_fields);
 
-    for field_id in 0..schema.fields.len() as FieldId {
+    for field_id in 0..num_fields as FieldId {
+        let start = col_w.pos();
         if let Some(col) = columns.numeric(field_id) {
-            let start = data.len();
             let mut pairs: Vec<(NumKey, DocId)> =
                 col.iter().filter(|(_, d)| live.contains(*d)).collect();
             pairs.sort_by(|a, b| a.0.cmp_key(&b.0).then(a.1.cmp(&b.1)));
-            write_u32(&mut data, pairs.len() as u32);
+            write_u32(&mut col_w, pairs.len() as u32)?;
             for (key, doc_id) in pairs {
                 match key {
                     NumKey::Int(i) => {
-                        write_u8(&mut data, NUMKEY_TAG_INT);
-                        write_i64(&mut data, i);
+                        write_u8(&mut col_w, NUMKEY_TAG_INT)?;
+                        write_i64(&mut col_w, i)?;
                     }
                     NumKey::Float(f) => {
-                        write_u8(&mut data, NUMKEY_TAG_FLOAT);
-                        write_f64(&mut data, f);
+                        write_u8(&mut col_w, NUMKEY_TAG_FLOAT)?;
+                        write_f64(&mut col_w, f)?;
                     }
                 }
-                write_u32(&mut data, doc_id);
+                write_u32(&mut col_w, doc_id)?;
             }
-            directory.push((FIELD_TAG_NUMERIC, start as u32, (data.len() - start) as u32));
+            directory.push((FIELD_TAG_NUMERIC, start, col_w.pos() - start));
         } else if let Some(col) = columns.keyword(field_id) {
-            let start = data.len();
-            let values: Vec<(&str, RoaringBitmap)> = col
+            let mut values: Vec<(&str, RoaringBitmap)> = col
                 .iter()
                 .filter_map(|(v, b)| {
                     let mut filtered = b.clone();
@@ -489,45 +592,40 @@ fn encode_columns(memtable: &MemTable, live: &RoaringBitmap, schema: &Collection
                     (!filtered.is_empty()).then_some((v, filtered))
                 })
                 .collect();
-            write_u32(&mut data, values.len() as u32);
+            values.sort_by(|a, b| a.0.cmp(b.0));
+            write_u32(&mut col_w, values.len() as u32)?;
             for (value, bitmap) in &values {
-                write_str(&mut data, value);
+                write_str(&mut col_w, value)?;
                 let mut ser = Vec::new();
                 bitmap.serialize_into(&mut ser).expect("writing to a Vec cannot fail");
-                write_bytes(&mut data, &ser);
+                write_bytes(&mut col_w, &ser)?;
             }
             let mut present = col.present().clone();
             present &= live;
             let mut ser = Vec::new();
             present.serialize_into(&mut ser).expect("writing to a Vec cannot fail");
-            write_bytes(&mut data, &ser);
-            directory.push((FIELD_TAG_KEYWORD, start as u32, (data.len() - start) as u32));
+            write_bytes(&mut col_w, &ser)?;
+            directory.push((FIELD_TAG_KEYWORD, start, col_w.pos() - start));
         } else {
             directory.push((FIELD_TAG_NONE, 0, 0));
         }
     }
 
-    // The directory's own size is known up front (fixed 9 bytes per field),
-    // so each entry's absolute offset can be computed directly — no need to
-    // write placeholders and patch them after the fact.
-    let data_start = (HEADER_LEN + 4 + schema.fields.len() * 9) as u32;
-
-    let mut buf = Vec::new();
-    write_header(&mut buf, COL_MAGIC);
-    write_u32(&mut buf, schema.fields.len() as u32);
+    let footer_start = col_w.pos();
+    write_u32(&mut col_w, num_fields as u32)?;
     for &(tag, offset, length) in &directory {
-        write_u8(&mut buf, tag);
-        write_u32(&mut buf, if tag == FIELD_TAG_NONE { 0 } else { offset + data_start });
-        write_u32(&mut buf, length);
+        write_u8(&mut col_w, tag)?;
+        write_u64(&mut col_w, offset)?;
+        write_u64(&mut col_w, length)?;
     }
-    buf.extend_from_slice(&data);
-    buf
+    write_u64(&mut col_w, footer_start)?;
+    Ok(())
 }
 
 struct ColEntry {
     tag: u8,
-    offset: u32,
-    length: u32,
+    offset: u64,
+    length: u64,
 }
 
 pub(crate) struct ColHeader {
@@ -535,14 +633,20 @@ pub(crate) struct ColHeader {
 }
 
 pub(crate) fn decode_col_header(bytes: &[u8]) -> Result<ColHeader> {
-    let mut cur = Cursor::new(bytes, "segment columns");
-    cur.read_header(COL_MAGIC)?;
+    let what = "segment columns";
+    {
+        let mut cur = Cursor::new(bytes, what);
+        cur.read_header(COL_MAGIC)?;
+    }
+    let footer_start = read_footer_start(bytes, what)?;
+
+    let mut cur = Cursor::new(&bytes[footer_start..bytes.len() - FOOTER_POINTER_LEN], what);
     let num_fields = cur.read_u32()? as usize;
     let mut directory = Vec::with_capacity(num_fields);
     for _ in 0..num_fields {
         let tag = cur.read_u8()?;
-        let offset = cur.read_u32()?;
-        let length = cur.read_u32()?;
+        let offset = cur.read_u64()?;
+        let length = cur.read_u64()?;
         directory.push(ColEntry { tag, offset, length });
     }
     Ok(ColHeader { directory })
@@ -603,20 +707,22 @@ pub(crate) fn decode_keyword_column(
 
 // --- doc store -----------------------------------------------------------
 //
-// Four parallel sections, every one addressable in O(1) from a `doc_id`:
+// One forward pass, one document at a time, in doc id order:
 //
-//   field_lengths  dense (end-base)*num_fields*u32          zero-copy read
-//   values_dir     dense (end-base)*num_fields*9 bytes       zero-copy for
-//                                                             scalars, one
-//                                                             offset hop into
-//                                                             `strings` for
-//                                                             text/arrays
-//   source_dir     dense (end-base)*8 bytes (offset,len)     one hop into
-//                                                             `source`, paid
-//                                                             only when a
-//                                                             document is
-//                                                             actually
-//                                                             materialized
+//   blob          value overflow (Str/Array) + source JSON, appended as
+//                 encountered, immediately after the header             streamed
+//   field_lengths dense (end-base)*num_fields*4                         bounded scratch,
+//   values_dir    dense (end-base)*num_fields*VALUE_SLOT_LEN            written after
+//   source_dir    dense (end-base)*12                                   the blob
+//   presence      serialized roaring bitmap
+//   footer        base/end/num_fields/presence_len/blob_len/footer_start
+//
+// The three dense sections are bounded by document count × field count, not
+// by document *content* — the same order of magnitude a memtable already
+// holds resident, and not what this format change is about. What it is
+// about is `blob`: raw text and JSON, the part that actually scales with
+// corpus size, which streams straight to the sink as each document is
+// visited instead of accumulating in a `Vec` for the whole segment.
 //
 // `field_lengths` is BM25's `|d|`, read once per scored document — it must
 // never cost an allocation, which is why it gets its own flat array instead
@@ -626,41 +732,47 @@ const VALUE_TAG_NULL: u8 = 0;
 const VALUE_TAG_BOOL: u8 = 1;
 const VALUE_TAG_INT: u8 = 2;
 const VALUE_TAG_FLOAT: u8 = 3;
-const VALUE_TAG_STR: u8 = 4;
-const VALUE_TAG_ARRAY: u8 = 5;
+pub(crate) const VALUE_TAG_STR: u8 = 4;
+pub(crate) const VALUE_TAG_ARRAY: u8 = 5;
 
-const VALUE_SLOT_LEN: usize = 9; // 1 tag byte + 8 data bytes
+/// 1 tag byte + 8-byte blob offset + 4-byte blob length. `Null`/`Bool`/
+/// `Int`/`Float` only use the first of those 12 payload bytes (or the first
+/// 9, for `Int`/`Float`'s inline value) and leave the rest zeroed; `Str`/
+/// `Array` use all of it to point into the blob. One width for every tag
+/// keeps the array directly indexable by `(doc, field)` — an `Int` costs the
+/// same 13 bytes a `Str` does, in exchange for O(1) addressing.
+const VALUE_SLOT_LEN: usize = 13;
 
-/// The general recursive encoding used for anything that doesn't fit a fixed
-/// 9-byte slot (`Str`, `Array`) — written into the `strings` section and
-/// referenced from a slot by `(offset, length)`.
-fn write_value_full(buf: &mut Vec<u8>, value: &Value) {
+/// The general recursive encoding used for `Str`/`Array` values — written
+/// into the blob and referenced from a slot by `(offset, length)`.
+fn write_value_full(w: &mut impl Write, value: &Value) -> Result<()> {
     match value {
-        Value::Null => write_u8(buf, VALUE_TAG_NULL),
+        Value::Null => write_u8(w, VALUE_TAG_NULL)?,
         Value::Bool(b) => {
-            write_u8(buf, VALUE_TAG_BOOL);
-            write_u8(buf, *b as u8);
+            write_u8(w, VALUE_TAG_BOOL)?;
+            write_u8(w, *b as u8)?;
         }
         Value::Int(i) => {
-            write_u8(buf, VALUE_TAG_INT);
-            write_i64(buf, *i);
+            write_u8(w, VALUE_TAG_INT)?;
+            write_i64(w, *i)?;
         }
         Value::Float(f) => {
-            write_u8(buf, VALUE_TAG_FLOAT);
-            write_f64(buf, *f);
+            write_u8(w, VALUE_TAG_FLOAT)?;
+            write_f64(w, *f)?;
         }
         Value::Str(s) => {
-            write_u8(buf, VALUE_TAG_STR);
-            write_str(buf, s);
+            write_u8(w, VALUE_TAG_STR)?;
+            write_str(w, s)?;
         }
         Value::Array(items) => {
-            write_u8(buf, VALUE_TAG_ARRAY);
-            write_u32(buf, items.len() as u32);
+            write_u8(w, VALUE_TAG_ARRAY)?;
+            write_u32(w, items.len() as u32)?;
             for item in items {
-                write_value_full(buf, item);
+                write_value_full(w, item)?;
             }
         }
     }
+    Ok(())
 }
 
 fn read_value_full(cur: &mut Cursor) -> Result<Value> {
@@ -682,9 +794,10 @@ fn read_value_full(cur: &mut Cursor) -> Result<Value> {
     }
 }
 
-/// Write one field's value into its fixed-width directory slot, spilling
-/// variable-length content (`Str`/`Array`) into `strings`.
-fn encode_value_slot(slot: &mut [u8], value: &Value, strings: &mut Vec<u8>) {
+/// Write one field's value into its fixed-width directory slot. `Str`/
+/// `Array` values must already have been written to the blob by the caller;
+/// `blob_offset`/`blob_len` locate those bytes. Every other tag ignores both.
+fn encode_value_slot(slot: &mut [u8], value: &Value, blob_offset: u64, blob_len: u32) {
     debug_assert_eq!(slot.len(), VALUE_SLOT_LEN);
     match value {
         Value::Null => slot[0] = VALUE_TAG_NULL,
@@ -702,29 +815,31 @@ fn encode_value_slot(slot: &mut [u8], value: &Value, strings: &mut Vec<u8>) {
         }
         Value::Str(_) | Value::Array(_) => {
             slot[0] = if matches!(value, Value::Str(_)) { VALUE_TAG_STR } else { VALUE_TAG_ARRAY };
-            let mut encoded = Vec::new();
-            write_value_full(&mut encoded, value);
-            let offset = strings.len() as u32;
-            let length = encoded.len() as u32;
-            strings.extend_from_slice(&encoded);
-            slot[1..5].copy_from_slice(&offset.to_le_bytes());
-            slot[5..9].copy_from_slice(&length.to_le_bytes());
+            slot[1..9].copy_from_slice(&blob_offset.to_le_bytes());
+            slot[9..13].copy_from_slice(&blob_len.to_le_bytes());
         }
     }
 }
 
-fn encode_docs(memtable: &MemTable, schema: &CollectionSchema) -> Vec<u8> {
+fn encode_docs_streaming(
+    memtable: &MemTable,
+    schema: &CollectionSchema,
+    doc_w: impl Write,
+) -> Result<()> {
+    let mut doc_w = CountingWriter::new(doc_w);
+    write_header(&mut doc_w, DOC_MAGIC)?;
+
     let base = memtable.base();
     let end = memtable.next_doc_id(); // exclusive
     let len = (end - base) as usize;
     let num_fields = schema.fields.len();
 
+    let blob_start = doc_w.pos();
+
     let mut presence = RoaringBitmap::new();
     let mut field_lengths = vec![0u8; len * num_fields * 4];
     let mut values_dir = vec![0u8; len * num_fields * VALUE_SLOT_LEN];
-    let mut strings = Vec::new();
-    let mut source_dir = vec![0u8; len * 8];
-    let mut source = Vec::new();
+    let mut source_dir = vec![0u8; len * 12]; // u64 offset + u32 length
 
     for (doc_id, doc) in memtable.iter() {
         presence.insert(doc_id);
@@ -737,48 +852,52 @@ fn encode_docs(memtable: &MemTable, schema: &CollectionSchema) -> Vec<u8> {
 
             let value = doc.values.get(f).unwrap_or(&Value::Null);
             let slot_pos = idx * num_fields * VALUE_SLOT_LEN + f * VALUE_SLOT_LEN;
+
+            let (blob_offset, blob_len) = if matches!(value, Value::Str(_) | Value::Array(_)) {
+                let offset = doc_w.pos();
+                write_value_full(&mut doc_w, value)?;
+                (offset, (doc_w.pos() - offset) as u32)
+            } else {
+                (0, 0)
+            };
             encode_value_slot(
                 &mut values_dir[slot_pos..slot_pos + VALUE_SLOT_LEN],
                 value,
-                &mut strings,
+                blob_offset,
+                blob_len,
             );
         }
 
-        let source_bytes =
-            serde_json::to_vec(&doc.source).expect("an already-parsed document is valid JSON");
-        let offset = source.len() as u32;
-        let length = source_bytes.len() as u32;
-        source.extend_from_slice(&source_bytes);
-        let sd_pos = idx * 8;
-        source_dir[sd_pos..sd_pos + 4].copy_from_slice(&offset.to_le_bytes());
-        source_dir[sd_pos + 4..sd_pos + 8].copy_from_slice(&length.to_le_bytes());
+        let source_offset = doc_w.pos();
+        serde_json::to_writer(&mut doc_w, &doc.source)?;
+        let source_len = (doc_w.pos() - source_offset) as u32;
+        let sd_pos = idx * 12;
+        source_dir[sd_pos..sd_pos + 8].copy_from_slice(&source_offset.to_le_bytes());
+        source_dir[sd_pos + 8..sd_pos + 12].copy_from_slice(&source_len.to_le_bytes());
     }
 
-    let mut buf = Vec::new();
-    write_header(&mut buf, DOC_MAGIC);
-    write_u32(&mut buf, base);
-    write_u32(&mut buf, end);
-    write_u32(&mut buf, num_fields as u32);
+    let blob_len = doc_w.pos() - blob_start;
+
+    doc_w.write_all(&field_lengths)?;
+    doc_w.write_all(&values_dir)?;
+    doc_w.write_all(&source_dir)?;
 
     let mut presence_bytes = Vec::new();
     presence.serialize_into(&mut presence_bytes).expect("writing to a Vec cannot fail");
-    write_u32(&mut buf, presence_bytes.len() as u32);
-    buf.extend_from_slice(&presence_bytes);
+    doc_w.write_all(&presence_bytes)?;
 
-    write_u32(&mut buf, strings.len() as u32);
-    write_u32(&mut buf, source.len() as u32);
-
-    buf.extend_from_slice(&field_lengths);
-    buf.extend_from_slice(&values_dir);
-    buf.extend_from_slice(&source_dir);
-    buf.extend_from_slice(&strings);
-    buf.extend_from_slice(&source);
-
-    buf
+    let footer_start = doc_w.pos();
+    write_u32(&mut doc_w, base)?;
+    write_u32(&mut doc_w, end)?;
+    write_u32(&mut doc_w, num_fields as u32)?;
+    write_u32(&mut doc_w, presence_bytes.len() as u32)?;
+    write_u64(&mut doc_w, blob_len)?;
+    write_u64(&mut doc_w, footer_start)?;
+    Ok(())
 }
 
 /// The small, eager part of `.doc`: the doc-id range, field count, presence
-/// bitmap, and the byte offsets of each section. O(corpus / 8) for the
+/// bitmap, and the byte offsets of each dense section. O(corpus / 8) for the
 /// presence bitmap (typically far less once roaring compresses a dense
 /// range); everything else here is O(1).
 pub(crate) struct DocHeader {
@@ -789,38 +908,39 @@ pub(crate) struct DocHeader {
     field_lengths_start: usize,
     values_dir_start: usize,
     source_dir_start: usize,
-    strings_start: usize,
-    source_start: usize,
 }
 
 pub(crate) fn decode_doc_header(bytes: &[u8]) -> Result<DocHeader> {
-    let mut cur = Cursor::new(bytes, "segment doc store");
-    cur.read_header(DOC_MAGIC)?;
+    let what = "segment doc store";
+    {
+        let mut cur = Cursor::new(bytes, what);
+        cur.read_header(DOC_MAGIC)?;
+    }
+    let footer_start = read_footer_start(bytes, what)?;
+
+    let mut cur = Cursor::new(&bytes[footer_start..bytes.len() - FOOTER_POINTER_LEN], what);
     let base = cur.read_u32()?;
     let end = cur.read_u32()?;
     if end < base {
         return Err(Error::corruption("segment doc store: end before base".to_string()));
     }
     let num_fields = cur.read_u32()? as usize;
-
     let presence_len = cur.read_u32()? as usize;
-    let presence = RoaringBitmap::deserialize_from(cur.read_exact(presence_len)?)?;
-
-    let strings_len = cur.read_u32()? as usize;
-    let source_len = cur.read_u32()? as usize;
+    let blob_len = cur.read_u64()?;
 
     let len = (end - base) as usize;
-    let field_lengths_start = cur.position();
+    let field_lengths_start = HEADER_LEN + blob_len as usize;
     let values_dir_start = field_lengths_start + len * num_fields * 4;
     let source_dir_start = values_dir_start + len * num_fields * VALUE_SLOT_LEN;
-    let strings_start = source_dir_start + len * 8;
-    let source_start = strings_start + strings_len;
-    let expected_end = source_start + source_len;
-    if expected_end > bytes.len() {
+    let presence_start = source_dir_start + len * 12;
+    let expected_end = presence_start + presence_len;
+    if expected_end > footer_start {
         return Err(Error::corruption(
-            "segment doc store: sections run past end of file".to_string(),
+            "segment doc store: sections run past the footer".to_string(),
         ));
     }
+    let presence =
+        RoaringBitmap::deserialize_from(bytes_at(bytes, presence_start, presence_len, what)?)?;
 
     Ok(DocHeader {
         base,
@@ -830,8 +950,6 @@ pub(crate) fn decode_doc_header(bytes: &[u8]) -> Result<DocHeader> {
         field_lengths_start,
         values_dir_start,
         source_dir_start,
-        strings_start,
-        source_start,
     })
 }
 
@@ -882,9 +1000,9 @@ pub(crate) fn value_at(
         VALUE_TAG_INT => Value::Int(i64_at(bytes, pos + 1, what)?),
         VALUE_TAG_FLOAT => Value::Float(f64_at(bytes, pos + 1, what)?),
         VALUE_TAG_STR | VALUE_TAG_ARRAY => {
-            let offset = u32_at(bytes, pos + 1, what)? as usize;
-            let length = u32_at(bytes, pos + 5, what)? as usize;
-            let slice = bytes_at(bytes, header.strings_start + offset, length, what)?;
+            let offset = u64_at(bytes, pos + 1, what)? as usize;
+            let length = u32_at(bytes, pos + 9, what)? as usize;
+            let slice = bytes_at(bytes, offset, length, what)?;
             let mut cur = Cursor::new(slice, what);
             read_value_full(&mut cur)?
         }
@@ -898,14 +1016,76 @@ pub(crate) fn value_at(
 pub(crate) fn source_at(bytes: &[u8], header: &DocHeader, doc_id: DocId) -> Result<Option<Json>> {
     let idx = doc_index(header, doc_id)?;
     let what = "segment doc store (source)";
-    let pos = header.source_dir_start + idx * 8;
-    let offset = u32_at(bytes, pos, what)? as usize;
-    let length = u32_at(bytes, pos + 4, what)? as usize;
+    let pos = header.source_dir_start + idx * 12;
+    let offset = u64_at(bytes, pos, what)? as usize;
+    let length = u32_at(bytes, pos + 8, what)? as usize;
     if length == 0 {
         return Ok(None);
     }
-    let slice = bytes_at(bytes, header.source_start + offset, length, what)?;
+    let slice = bytes_at(bytes, offset, length, what)?;
     Ok(Some(serde_json::from_slice(slice)?))
+}
+
+/// The document's verbatim source JSON as raw bytes, with no parse — used by
+/// the streaming merge path to copy a document's stored form into a new
+/// segment's blob without round-tripping it through `serde_json::Value`.
+pub(crate) fn raw_source_at<'a>(
+    bytes: &'a [u8],
+    header: &DocHeader,
+    doc_id: DocId,
+) -> Result<Option<&'a [u8]>> {
+    let idx = doc_index(header, doc_id)?;
+    let what = "segment doc store (source)";
+    let pos = header.source_dir_start + idx * 12;
+    let offset = u64_at(bytes, pos, what)? as usize;
+    let length = u32_at(bytes, pos + 8, what)? as usize;
+    if length == 0 {
+        return Ok(None);
+    }
+    Ok(Some(bytes_at(bytes, offset, length, what)?))
+}
+
+/// A field's raw value-slot bytes and, if the tag is `Str`/`Array`, the raw
+/// blob bytes they point at — used by the streaming merge path to copy a
+/// document's value into a new segment without decoding it into a `Value`
+/// and re-encoding, for every field whose slot doesn't need rebasing (i.e.
+/// isn't `Str`/`Array`) or whose blob bytes can be copied verbatim.
+pub(crate) fn raw_value_slot_at<'a>(
+    bytes: &'a [u8],
+    header: &DocHeader,
+    doc_id: DocId,
+    field: FieldId,
+) -> Result<(u8, &'a [u8], u64, u32)> {
+    let idx = doc_index(header, doc_id)?;
+    let what = "segment doc store (value)";
+    if field as usize >= header.num_fields {
+        return Err(Error::corruption(format!("{what}: field out of range")));
+    }
+    let pos = header.values_dir_start
+        + idx * header.num_fields * VALUE_SLOT_LEN
+        + field as usize * VALUE_SLOT_LEN;
+    let slot = bytes_at(bytes, pos, VALUE_SLOT_LEN, what)?;
+    let tag = slot[0];
+    match tag {
+        VALUE_TAG_STR | VALUE_TAG_ARRAY => {
+            let offset = u64_at(bytes, pos + 1, what)? as usize;
+            let length = u32_at(bytes, pos + 9, what)? as usize;
+            let blob = bytes_at(bytes, offset, length, what)?;
+            Ok((tag, blob, offset as u64, length as u32))
+        }
+        _ => Ok((tag, slot, 0, 0)),
+    }
+}
+
+pub(crate) fn field_lengths_row<'a>(
+    bytes: &'a [u8],
+    header: &DocHeader,
+    doc_id: DocId,
+) -> Result<&'a [u8]> {
+    let idx = doc_index(header, doc_id)?;
+    let what = "segment doc store (field length)";
+    let pos = header.field_lengths_start + idx * header.num_fields * 4;
+    bytes_at(bytes, pos, header.num_fields * 4, what)
 }
 
 #[cfg(test)]
@@ -1331,5 +1511,41 @@ mod tests {
         let term_id = terms.get("mouse").unwrap();
 
         assert!(decode_term_field_blocks(&encoded.post, &header, term_id, 1).unwrap().is_none());
+    }
+
+    #[test]
+    fn encoding_the_same_memtable_twice_produces_byte_identical_segments() {
+        // The pre-v4 encoder's `.col` keyword section iterated a `HashMap`
+        // directly, so two encodes of the same live document set were not
+        // guaranteed to agree byte-for-byte even though nothing depended on
+        // that — this pins the determinism the streaming merge path's own
+        // equivalence tests lean on.
+        let schema = CollectionSchema::new(
+            "things",
+            vec![
+                FieldSchema::new("title", FieldType::Text),
+                FieldSchema::new("brand", FieldType::Keyword).with_facet(true),
+            ],
+        );
+        let mut m = MemTable::new(0, &schema);
+        for (i, brand) in
+            ["Logitech", "Razer", "Anker", "Corsair", "HyperX", "SteelSeries"].iter().enumerate()
+        {
+            m.insert(
+                ParsedDocument::parse(
+                    json!({ "id": i.to_string(), "title": format!("item {i}"), "brand": brand }),
+                    &schema,
+                )
+                .unwrap(),
+            );
+        }
+
+        let a = encode(&m, &schema).unwrap();
+        let b = encode(&m, &schema).unwrap();
+        assert_eq!(a.terms, b.terms);
+        assert_eq!(a.ids, b.ids);
+        assert_eq!(a.post, b.post);
+        assert_eq!(a.col, b.col);
+        assert_eq!(a.doc, b.doc);
     }
 }

--- a/crates/tachyon-index/src/segment/format.rs
+++ b/crates/tachyon-index/src/segment/format.rs
@@ -7,17 +7,36 @@
 //! whenever the tokenizer changes — see `tokenizer.rs`'s warning that a
 //! tokenizer change invalidates existing segments.
 
+use std::io::Write;
+
 use tachyon_core::{Error, Result};
 
+/// v4: `.post`, `.col`, and `.doc` moved their directory (offset table /
+/// column directory / doc-store section table) from the front of the file to
+/// a footer at the end, so a writer can stream payload bytes forward as it
+/// goes and only needs to know the directory's *contents* — never its
+/// position — once everything before it has already been written. Nothing
+/// about how a query reads a segment changed; this only changes how one gets
+/// written, which is `tachyon-engine`'s `SegmentWriter`/merge path, not this
+/// crate's query-time decode functions. Also widens every byte offset that
+/// pointed into a variable-length blob (`.doc`'s value/source blob, `.col`'s
+/// per-field data) from `u32` to `u64` — those blobs hold document text and
+/// scale with corpus size, and a `u32` offset silently wrapped past 4 GiB.
+///
 /// v3: `.post` postings are grouped into fixed-size blocks with per-block
 /// skip metadata (max doc id, max term frequency, byte offset/length), so a
 /// query can skip a block — or jump straight to one — without decoding the
-/// blocks in between. v1/v2 segments are not readable by this build — same
-/// policy as a tokenizer change, which also invalidates existing segments.
-pub const SEGMENT_FORMAT_VERSION: u32 = 3;
+/// blocks in between. v1/v2/v3 segments are not readable by this build —
+/// same policy as a tokenizer change, which also invalidates existing
+/// segments.
+pub const SEGMENT_FORMAT_VERSION: u32 = 4;
 
 /// Byte length of every segment file's header (8-byte magic + 4-byte version).
 pub const HEADER_LEN: usize = 12;
+
+/// Byte length of the trailing pointer every footer-based file (`.post`,
+/// `.col`, `.doc`) ends with: the absolute file offset its footer starts at.
+pub const FOOTER_POINTER_LEN: usize = 8;
 
 pub const TERMS_MAGIC: &[u8; 8] = b"TCHYTRM\0";
 pub const IDS_MAGIC: &[u8; 8] = b"TCHYIDS\0";
@@ -25,32 +44,78 @@ pub const POST_MAGIC: &[u8; 8] = b"TCHYPST\0";
 pub const COL_MAGIC: &[u8; 8] = b"TCHYCOL\0";
 pub const DOC_MAGIC: &[u8; 8] = b"TCHYDOC\0";
 
-pub fn write_header(buf: &mut Vec<u8>, magic: &[u8; 8]) {
-    buf.extend_from_slice(magic);
-    buf.extend_from_slice(&SEGMENT_FORMAT_VERSION.to_le_bytes());
+/// Every `write_*` primitive is generic over [`Write`] rather than tied to
+/// `Vec<u8>`, so the exact same encoding logic works whether the destination
+/// is a real file (the streaming path segment writing and merging use) or an
+/// in-memory buffer (what `codec::encode`'s tests build against) — one
+/// implementation of the byte format, not two that could drift apart. A
+/// `Vec<u8>`'s own `Write` impl never fails, so the `Result` these return
+/// costs nothing there; it matters only for the real-file case.
+pub fn write_header(w: &mut impl Write, magic: &[u8; 8]) -> Result<()> {
+    w.write_all(magic)?;
+    w.write_all(&SEGMENT_FORMAT_VERSION.to_le_bytes())?;
+    Ok(())
 }
 
-pub fn write_u8(buf: &mut Vec<u8>, v: u8) {
-    buf.push(v);
+pub fn write_u8(w: &mut impl Write, v: u8) -> Result<()> {
+    w.write_all(&[v])?;
+    Ok(())
 }
-pub fn write_u32(buf: &mut Vec<u8>, v: u32) {
-    buf.extend_from_slice(&v.to_le_bytes());
+pub fn write_u32(w: &mut impl Write, v: u32) -> Result<()> {
+    w.write_all(&v.to_le_bytes())?;
+    Ok(())
 }
-pub fn write_u64(buf: &mut Vec<u8>, v: u64) {
-    buf.extend_from_slice(&v.to_le_bytes());
+pub fn write_u64(w: &mut impl Write, v: u64) -> Result<()> {
+    w.write_all(&v.to_le_bytes())?;
+    Ok(())
 }
-pub fn write_i64(buf: &mut Vec<u8>, v: i64) {
-    buf.extend_from_slice(&v.to_le_bytes());
+pub fn write_i64(w: &mut impl Write, v: i64) -> Result<()> {
+    w.write_all(&v.to_le_bytes())?;
+    Ok(())
 }
-pub fn write_f64(buf: &mut Vec<u8>, v: f64) {
-    buf.extend_from_slice(&v.to_le_bytes());
+pub fn write_f64(w: &mut impl Write, v: f64) -> Result<()> {
+    w.write_all(&v.to_le_bytes())?;
+    Ok(())
 }
-pub fn write_bytes(buf: &mut Vec<u8>, bytes: &[u8]) {
-    write_u32(buf, bytes.len() as u32);
-    buf.extend_from_slice(bytes);
+pub fn write_bytes(w: &mut impl Write, bytes: &[u8]) -> Result<()> {
+    write_u32(w, bytes.len() as u32)?;
+    w.write_all(bytes)?;
+    Ok(())
 }
-pub fn write_str(buf: &mut Vec<u8>, s: &str) {
-    write_bytes(buf, s.as_bytes());
+pub fn write_str(w: &mut impl Write, s: &str) -> Result<()> {
+    write_bytes(w, s.as_bytes())
+}
+
+/// Wraps any [`Write`] to track the number of bytes written so far, so a
+/// streaming writer can record "the block I'm about to write starts at byte
+/// N" without the sink itself (a plain [`std::fs::File`] most of the time)
+/// being seekable or otherwise able to answer that question.
+pub struct CountingWriter<W> {
+    inner: W,
+    pos: u64,
+}
+
+impl<W> CountingWriter<W> {
+    pub fn new(inner: W) -> CountingWriter<W> {
+        CountingWriter { inner, pos: 0 }
+    }
+
+    /// Bytes written so far.
+    pub fn pos(&self) -> u64 {
+        self.pos
+    }
+}
+
+impl<W: Write> Write for CountingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let n = self.inner.write(buf)?;
+        self.pos += n as u64;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
 }
 
 /// A read cursor over a decoded segment blob, with bounds-checked primitives.
@@ -166,7 +231,12 @@ fn slice_at<'a>(
     let end = offset
         .checked_add(len)
         .ok_or_else(|| Error::corruption(format!("{what}: offset overflow")))?;
-    bytes.get(offset..end).ok_or_else(|| Error::corruption(format!("{what}: offset out of range")))
+    bytes.get(offset..end).ok_or_else(|| {
+        Error::corruption(format!(
+            "{what}: offset out of range (offset={offset} len={len} end={end} bytes.len()={})",
+            bytes.len()
+        ))
+    })
 }
 
 pub fn u8_at(bytes: &[u8], offset: usize, what: &'static str) -> Result<u8> {
@@ -175,6 +245,10 @@ pub fn u8_at(bytes: &[u8], offset: usize, what: &'static str) -> Result<u8> {
 
 pub fn u32_at(bytes: &[u8], offset: usize, what: &'static str) -> Result<u32> {
     Ok(u32::from_le_bytes(slice_at(bytes, offset, 4, what)?.try_into().expect("4 bytes")))
+}
+
+pub fn u64_at(bytes: &[u8], offset: usize, what: &'static str) -> Result<u64> {
+    Ok(u64::from_le_bytes(slice_at(bytes, offset, 8, what)?.try_into().expect("8 bytes")))
 }
 
 pub fn i64_at(bytes: &[u8], offset: usize, what: &'static str) -> Result<i64> {

--- a/crates/tachyon-index/src/segment/format.rs
+++ b/crates/tachyon-index/src/segment/format.rs
@@ -199,12 +199,6 @@ impl<'a> Cursor<'a> {
         std::str::from_utf8(self.read_bytes()?).map_err(|_| self.err())
     }
 
-    /// Exactly `n` bytes, with no length prefix of their own — for a length
-    /// already known from elsewhere (e.g. a field read just before this one).
-    pub fn read_exact(&mut self, n: usize) -> Result<&'a [u8]> {
-        self.take(n)
-    }
-
     /// Advance past `n` bytes without reading them — for skipping data a
     /// caller doesn't need (e.g. positions, when only a document count is
     /// wanted) without paying to decode and allocate it.

--- a/crates/tachyon-index/src/segment/merge.rs
+++ b/crates/tachyon-index/src/segment/merge.rs
@@ -1,0 +1,1363 @@
+//! Stream several already-encoded segments into one, without ever
+//! materializing the merged corpus as a `MemTable` the way the pre-v4 merge
+//! did (parse every live document's stored source again, re-tokenize it, and
+//! insert it into a fresh in-memory index before encoding that). Every
+//! document here was already tokenized once, when its segment was first
+//! flushed; a merge's job is to copy that work forward, not redo it.
+//!
+//! # Doc id remapping
+//!
+//! A merge renumbers rather than preserves doc ids — see
+//! `tachyon-engine::Collection::merge_locked`'s doc comment for why. Given
+//! the merge's output base id and, per input segment, a `live` bitmap (that
+//! segment's own presence, already intersected with the engine's
+//! collection-wide tombstones), an old doc id remaps to:
+//!
+//! ```text
+//! new_base[i] + live[i].rank(old_id) - 1
+//! ```
+//!
+//! `rank(x)` (from `roaring`) is the count of set bits `<= x`, so this is
+//! "how many live documents in this input come at or before this one,
+//! 0-indexed" — dense and monotone within one input. `new_base[i]` is a
+//! running total of every earlier input's live count, so ids stay monotone
+//! *across* inputs too: every posting, column entry, and doc-store row this
+//! module writes comes out already in ascending new-doc-id order, with no
+//! sort needed after the fact.
+//!
+//! # What's copied verbatim vs. recomputed
+//!
+//! Term postings are decoded down to `(doc_id, positions)` and re-blocked
+//! (block boundaries shift because dead documents drop out and ids change),
+//! but positions themselves are copied, not retokenized. A value slot for
+//! `Null`/`Bool`/`Int`/`Float` doesn't reference anything positional, so its
+//! 13 raw bytes are copied without even being decoded into a [`Value`]; a
+//! `Str`/`Array` slot's blob bytes are copied verbatim and only its offset is
+//! rebased to the new file's position. A document's stored source JSON is
+//! copied as raw bytes ([`super::codec::raw_source_at`]), never re-parsed or
+//! re-serialized. Only postings actually need decoding at all, and only
+//! because block boundaries genuinely change.
+
+use std::collections::HashMap;
+use std::io::Write;
+
+use roaring::RoaringBitmap;
+
+use tachyon_core::{CollectionSchema, DocId, Error, FieldId, Result};
+
+use crate::columns::NumKey;
+
+use super::codec::{self, BlockMeta, POSTING_BLOCK_SIZE};
+use super::format::{
+    write_f64, write_header, write_i64, write_str, write_u32, write_u64, write_u8, CountingWriter,
+    COL_MAGIC, DOC_MAGIC, IDS_MAGIC, POST_MAGIC, TERMS_MAGIC,
+};
+use super::reader::SegmentReader;
+
+/// One segment being folded into the merge output: the reader, and the
+/// subset of its own doc ids that should survive — its own presence bitmap
+/// intersected with whatever the engine has tombstoned since this segment
+/// was written. Inputs are processed in the order given; that order is what
+/// determines each one's slice of the output id range (see this module's
+/// doc comment), so callers that care about which victim's ids sort first
+/// (`tachyon-engine` does, to preserve relative recency) must pass them in
+/// that order.
+pub struct MergeInput<'a> {
+    pub reader: &'a SegmentReader,
+    pub live: RoaringBitmap,
+}
+
+pub struct MergeStats {
+    /// Total documents written to the output segment.
+    pub doc_count: usize,
+}
+
+/// Stream `inputs` into one segment starting at doc id `base`, writing
+/// directly into the five sinks. Bounded memory throughout: the largest
+/// single thing held in memory at once is one term-field's merged postings,
+/// one field's merged column, or one document's id-string/blob bytes — never
+/// the whole merged corpus, which is the entire point of streaming a merge
+/// instead of rebuilding a `MemTable` from it.
+///
+/// A no-op-shaped call (empty `inputs`, or every input's `live` empty)
+/// produces a valid, empty segment rather than being special-cased — the
+/// caller (`Collection::merge_locked`) already skips writing anything when
+/// nothing would end up live, but nothing here requires that.
+///
+/// Eight parameters, five of them the segment's own file sinks: a segment
+/// really is five separate structures with no shared framing (see
+/// `segment/mod.rs`'s doc comment), and threading them through a struct
+/// instead would just move this same count onto a builder's fields.
+#[allow(clippy::too_many_arguments)]
+pub fn merge_segments(
+    inputs: &[MergeInput<'_>],
+    schema: &CollectionSchema,
+    base: DocId,
+    terms_w: impl Write,
+    ids_w: impl Write,
+    post_w: impl Write,
+    col_w: impl Write,
+    doc_w: impl Write,
+) -> Result<MergeStats> {
+    let mut new_base = Vec::with_capacity(inputs.len());
+    let mut cursor = base;
+    for input in inputs {
+        new_base.push(cursor);
+        cursor += input.live.len() as DocId;
+    }
+    let out_end = cursor;
+    let doc_count = (out_end - base) as usize;
+
+    merge_postings_and_terms(inputs, &new_base, schema, terms_w, post_w)?;
+    merge_ids(inputs, &new_base, ids_w)?;
+    merge_columns(inputs, &new_base, schema, col_w)?;
+    merge_docs(inputs, &new_base, schema, base, out_end, doc_w)?;
+
+    Ok(MergeStats { doc_count })
+}
+
+/// `old_id`'s new id under input `i`, or `None` if it didn't survive.
+fn remap(input: &MergeInput, new_base: DocId, old_id: DocId) -> Option<DocId> {
+    if !input.live.contains(old_id) {
+        return None;
+    }
+    Some(new_base + (input.live.rank(old_id) - 1) as DocId)
+}
+
+// --- ids -----------------------------------------------------------------
+
+fn merge_ids(inputs: &[MergeInput], new_base: &[DocId], ids_w: impl Write) -> Result<()> {
+    use fst::Streamer;
+
+    let mut pairs: Vec<(String, u64)> = Vec::new();
+    for (i, input) in inputs.iter().enumerate() {
+        let mut stream = input.reader.ids_map().stream();
+        while let Some((id_bytes, old_id)) = stream.next() {
+            let Some(new_id) = remap(input, new_base[i], old_id as DocId) else { continue };
+            let id = std::str::from_utf8(id_bytes)
+                .map_err(|_| Error::corruption("segment merge: non-utf8 document id"))?;
+            pairs.push((id.to_string(), new_id as u64));
+        }
+    }
+    pairs.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+    codec::write_fst(ids_w, IDS_MAGIC, pairs.iter().map(|(s, v)| (s.as_str(), *v)))
+}
+
+// --- postings + terms ------------------------------------------------------
+
+/// One posting, already remapped to its new doc id and with positions
+/// decoded — the unit a term-field's output blocks are built from. Owned
+/// rather than borrowed, unlike the flush path's `&DocPosting`: a merge's
+/// positions come from decoding an input segment's bytes fresh, not from
+/// something already resident that a reference could point at.
+struct MergedPosting {
+    doc_id: DocId,
+    positions: Vec<u32>,
+}
+
+/// Every surviving posting for one (term, field) across every input,
+/// already in ascending new-doc-id order (see this module's doc comment) —
+/// bounded by this one term-field's total postings, the same bound the
+/// flush path already accepts for a single term's block-building pass.
+fn collect_field_postings(
+    inputs: &[MergeInput],
+    new_base: &[DocId],
+    term_lookup: &[Option<u64>],
+    field: FieldId,
+) -> Result<Vec<MergedPosting>> {
+    let mut out = Vec::new();
+    for (i, input) in inputs.iter().enumerate() {
+        let Some(term_id) = term_lookup[i] else { continue };
+        let Some(term_field) = codec::decode_term_field_blocks(
+            input.reader.post_bytes(),
+            input.reader.post_header(),
+            term_id,
+            field,
+        )?
+        else {
+            continue;
+        };
+        for meta in &term_field.blocks {
+            let skeleton = codec::decode_block_skeleton(input.reader.post_bytes(), meta)?;
+            for j in 0..skeleton.doc_ids.len() {
+                let Some(new_id) = remap(input, new_base[i], skeleton.doc_ids[j]) else { continue };
+                let positions = codec::decode_positions_at(
+                    input.reader.post_bytes(),
+                    skeleton.positions_offsets[j],
+                    skeleton.tfs[j],
+                )?;
+                out.push(MergedPosting { doc_id: new_id, positions });
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn write_merged_field_blocks(
+    post_w: &mut CountingWriter<impl Write>,
+    postings: &[MergedPosting],
+) -> Result<()> {
+    let chunks: Vec<&[MergedPosting]> = postings.chunks(POSTING_BLOCK_SIZE).collect();
+    write_u32(post_w, chunks.len() as u32)?;
+
+    // Same two-pass-within-a-field-section shape as the flush encoder: a
+    // block's own offset must be known before its directory entry is
+    // written, and the directory precedes the payloads on disk.
+    let mut payloads = Vec::new();
+    let mut metas = Vec::with_capacity(chunks.len());
+    for chunk in &chunks {
+        let start = payloads.len() as u64;
+        write_u32(&mut payloads, chunk.len() as u32)?;
+        let mut max_tf = 0u32;
+        for posting in chunk.iter() {
+            write_u32(&mut payloads, posting.doc_id)?;
+            write_u32(&mut payloads, posting.positions.len() as u32)?;
+            for &p in &posting.positions {
+                write_u32(&mut payloads, p)?;
+            }
+            max_tf = max_tf.max(posting.positions.len() as u32);
+        }
+        metas.push(BlockMeta {
+            last_doc_id: chunk.last().expect("chunks() never yields an empty slice").doc_id,
+            max_tf,
+            offset: start,
+            length: (payloads.len() as u64 - start) as u32,
+        });
+    }
+
+    let payload_base = post_w.pos() + metas.len() as u64 * 20;
+    for meta in &metas {
+        codec::write_block_meta(
+            post_w,
+            &BlockMeta { offset: payload_base + meta.offset, ..*meta },
+        )?;
+    }
+    post_w.write_all(&payloads)?;
+    Ok(())
+}
+
+fn merge_postings_and_terms(
+    inputs: &[MergeInput],
+    new_base: &[DocId],
+    schema: &CollectionSchema,
+    mut terms_w: impl Write,
+    post_w: impl Write,
+) -> Result<()> {
+    let num_fields = schema.fields.len();
+
+    // Field stats over exactly the documents that will survive — cheap
+    // (O(live docs × fields), no postings touched) and needed up front
+    // since it lands in the footer alongside the offset table.
+    let mut field_doc_count = vec![0u32; num_fields];
+    let mut field_total_len = vec![0u64; num_fields];
+    for input in inputs {
+        for old_id in input.live.iter() {
+            let row = codec::field_lengths_row(
+                input.reader.doc_bytes(),
+                input.reader.doc_header(),
+                old_id,
+            )?;
+            for f in 0..num_fields {
+                let len = u32::from_le_bytes(row[f * 4..f * 4 + 4].try_into().expect("4 bytes"));
+                if len > 0 {
+                    field_doc_count[f] += 1;
+                    field_total_len[f] += len as u64;
+                }
+            }
+        }
+    }
+
+    let mut post_w = CountingWriter::new(post_w);
+    write_header(&mut post_w, POST_MAGIC)?;
+    write_header(&mut terms_w, TERMS_MAGIC)?;
+    let mut terms_builder = fst::MapBuilder::new(terms_w)
+        .map_err(|e| Error::internal(format!("building segment term dictionary: {e}")))?;
+
+    let mut term_offsets: Vec<u64> = Vec::new();
+    let mut out_term_id: u64 = 0;
+
+    let mut op = fst::map::OpBuilder::new();
+    for input in inputs {
+        op = op.add(input.reader.terms_map());
+    }
+    let mut union = op.union();
+
+    let mut term_lookup = vec![None; inputs.len()];
+    use fst::Streamer;
+    while let Some((term_bytes, ivs)) = union.next() {
+        let term = std::str::from_utf8(term_bytes)
+            .map_err(|_| Error::corruption("segment merge: non-utf8 term"))?;
+
+        term_lookup.iter_mut().for_each(|v| *v = None);
+        for iv in ivs {
+            term_lookup[iv.index] = Some(iv.value);
+        }
+
+        let mut kept_fields: Vec<(FieldId, Vec<MergedPosting>)> = Vec::new();
+        for field in 0..num_fields as FieldId {
+            let postings = collect_field_postings(inputs, new_base, &term_lookup, field)
+                .map_err(|e| Error::corruption(format!("term={term:?} field={field}: {e}")))?;
+            if !postings.is_empty() {
+                kept_fields.push((field, postings));
+            }
+        }
+        if kept_fields.is_empty() {
+            continue;
+        }
+
+        term_offsets.push(post_w.pos());
+        terms_builder
+            .insert(term, out_term_id)
+            .map_err(|e| Error::internal(format!("building segment term dictionary: {e}")))?;
+        out_term_id += 1;
+
+        write_u32(&mut post_w, kept_fields.len() as u32)?;
+        for (field, postings) in &kept_fields {
+            write_u32(&mut post_w, *field as u32)?;
+            write_u32(&mut post_w, postings.len() as u32)?;
+            write_merged_field_blocks(&mut post_w, postings)?;
+        }
+    }
+
+    terms_builder
+        .finish()
+        .map_err(|e| Error::internal(format!("finishing term dictionary: {e}")))?;
+
+    let footer_start = post_w.pos();
+    write_u32(&mut post_w, num_fields as u32)?;
+    for f in 0..num_fields {
+        write_u32(&mut post_w, field_doc_count[f])?;
+        write_u64(&mut post_w, field_total_len[f])?;
+    }
+    write_u32(&mut post_w, term_offsets.len() as u32)?;
+    for off in &term_offsets {
+        write_u64(&mut post_w, *off)?;
+    }
+    write_u64(&mut post_w, footer_start)?;
+    Ok(())
+}
+
+// --- columns ---------------------------------------------------------------
+
+fn merge_columns(
+    inputs: &[MergeInput],
+    new_base: &[DocId],
+    schema: &CollectionSchema,
+    col_w: impl Write,
+) -> Result<()> {
+    let mut col_w = CountingWriter::new(col_w);
+    write_header(&mut col_w, COL_MAGIC)?;
+
+    let num_fields = schema.fields.len();
+    let mut directory: Vec<(u8, u64, u64)> = Vec::with_capacity(num_fields);
+
+    for (field, fs) in schema.fields.iter().enumerate() {
+        let field = field as FieldId;
+        let start = col_w.pos();
+
+        if !fs.needs_column() {
+            directory.push((codec::FIELD_TAG_NONE, 0, 0));
+            continue;
+        }
+
+        if fs.field_type.is_numeric() {
+            let mut pairs: Vec<(NumKey, DocId)> = Vec::new();
+            for (i, input) in inputs.iter().enumerate() {
+                if let Some(col) = codec::decode_numeric_column(
+                    input.reader.col_bytes(),
+                    input.reader.col_header(),
+                    field,
+                )? {
+                    for (key, old_id) in col.iter() {
+                        if let Some(new_id) = remap(input, new_base[i], old_id) {
+                            pairs.push((key, new_id));
+                        }
+                    }
+                }
+            }
+            pairs.sort_by(|a, b| a.0.cmp_key(&b.0).then(a.1.cmp(&b.1)));
+            write_u32(&mut col_w, pairs.len() as u32)?;
+            for (key, doc_id) in pairs {
+                match key {
+                    NumKey::Int(v) => {
+                        write_u8(&mut col_w, codec::NUMKEY_TAG_INT)?;
+                        write_i64(&mut col_w, v)?;
+                    }
+                    NumKey::Float(v) => {
+                        write_u8(&mut col_w, codec::NUMKEY_TAG_FLOAT)?;
+                        write_f64(&mut col_w, v)?;
+                    }
+                }
+                write_u32(&mut col_w, doc_id)?;
+            }
+            directory.push((codec::FIELD_TAG_NUMERIC, start, col_w.pos() - start));
+        } else {
+            let mut by_value: HashMap<String, RoaringBitmap> = HashMap::new();
+            for (i, input) in inputs.iter().enumerate() {
+                if let Some(col) = codec::decode_keyword_column(
+                    input.reader.col_bytes(),
+                    input.reader.col_header(),
+                    field,
+                )? {
+                    for (value, bitmap) in col.iter() {
+                        let entry = by_value.entry(value.to_string()).or_default();
+                        for old_id in bitmap.iter() {
+                            if let Some(new_id) = remap(input, new_base[i], old_id) {
+                                entry.insert(new_id);
+                            }
+                        }
+                    }
+                }
+            }
+            let mut values: Vec<(String, RoaringBitmap)> =
+                by_value.into_iter().filter(|(_, b)| !b.is_empty()).collect();
+            values.sort_by(|a, b| a.0.cmp(&b.0));
+
+            write_u32(&mut col_w, values.len() as u32)?;
+            let mut present = RoaringBitmap::new();
+            for (value, bitmap) in &values {
+                write_str(&mut col_w, value)?;
+                let mut ser = Vec::new();
+                bitmap.serialize_into(&mut ser).expect("writing to a Vec cannot fail");
+                write_u32(&mut col_w, ser.len() as u32)?;
+                col_w.write_all(&ser)?;
+                present |= bitmap;
+            }
+            let mut ser = Vec::new();
+            present.serialize_into(&mut ser).expect("writing to a Vec cannot fail");
+            write_u32(&mut col_w, ser.len() as u32)?;
+            col_w.write_all(&ser)?;
+            directory.push((codec::FIELD_TAG_KEYWORD, start, col_w.pos() - start));
+        }
+    }
+
+    let footer_start = col_w.pos();
+    write_u32(&mut col_w, num_fields as u32)?;
+    for &(tag, offset, length) in &directory {
+        write_u8(&mut col_w, tag)?;
+        write_u64(&mut col_w, offset)?;
+        write_u64(&mut col_w, length)?;
+    }
+    write_u64(&mut col_w, footer_start)?;
+    Ok(())
+}
+
+// --- doc store ---------------------------------------------------------
+
+fn merge_docs(
+    inputs: &[MergeInput],
+    new_base: &[DocId],
+    schema: &CollectionSchema,
+    out_base: DocId,
+    out_end: DocId,
+    doc_w: impl Write,
+) -> Result<()> {
+    let mut doc_w = CountingWriter::new(doc_w);
+    write_header(&mut doc_w, DOC_MAGIC)?;
+    let blob_start = doc_w.pos();
+
+    let num_fields = schema.fields.len();
+    let len = (out_end - out_base) as usize;
+
+    let mut presence = RoaringBitmap::new();
+    let mut field_lengths = vec![0u8; len * num_fields * 4];
+    let mut values_dir = vec![0u8; len * num_fields * 13];
+    let mut source_dir = vec![0u8; len * 12];
+
+    for (i, input) in inputs.iter().enumerate() {
+        for old_id in input.live.iter() {
+            let new_id = new_base[i] + (input.live.rank(old_id) - 1) as DocId;
+            presence.insert(new_id);
+            let idx = (new_id - out_base) as usize;
+
+            let row = codec::field_lengths_row(
+                input.reader.doc_bytes(),
+                input.reader.doc_header(),
+                old_id,
+            )?;
+            field_lengths[idx * num_fields * 4..idx * num_fields * 4 + num_fields * 4]
+                .copy_from_slice(row);
+
+            for f in 0..num_fields as FieldId {
+                let (tag, payload, ..) = codec::raw_value_slot_at(
+                    input.reader.doc_bytes(),
+                    input.reader.doc_header(),
+                    old_id,
+                    f,
+                )?;
+                let slot_pos = idx * num_fields * 13 + f as usize * 13;
+                if matches!(tag, codec::VALUE_TAG_STR | codec::VALUE_TAG_ARRAY) {
+                    let new_offset = doc_w.pos();
+                    doc_w.write_all(payload)?;
+                    values_dir[slot_pos] = tag;
+                    values_dir[slot_pos + 1..slot_pos + 9]
+                        .copy_from_slice(&new_offset.to_le_bytes());
+                    values_dir[slot_pos + 9..slot_pos + 13]
+                        .copy_from_slice(&(payload.len() as u32).to_le_bytes());
+                } else {
+                    values_dir[slot_pos..slot_pos + 13].copy_from_slice(payload);
+                }
+            }
+
+            let source =
+                codec::raw_source_at(input.reader.doc_bytes(), input.reader.doc_header(), old_id)?
+                    .ok_or_else(|| {
+                        Error::corruption("segment merge: a live document has no stored source")
+                    })?;
+            let source_offset = doc_w.pos();
+            doc_w.write_all(source)?;
+            let sd_pos = idx * 12;
+            source_dir[sd_pos..sd_pos + 8].copy_from_slice(&source_offset.to_le_bytes());
+            source_dir[sd_pos + 8..sd_pos + 12]
+                .copy_from_slice(&(source.len() as u32).to_le_bytes());
+        }
+    }
+
+    let blob_len = doc_w.pos() - blob_start;
+
+    doc_w.write_all(&field_lengths)?;
+    doc_w.write_all(&values_dir)?;
+    doc_w.write_all(&source_dir)?;
+
+    let mut presence_bytes = Vec::new();
+    presence.serialize_into(&mut presence_bytes).expect("writing to a Vec cannot fail");
+    doc_w.write_all(&presence_bytes)?;
+
+    let footer_start = doc_w.pos();
+    write_u32(&mut doc_w, out_base)?;
+    write_u32(&mut doc_w, out_end)?;
+    write_u32(&mut doc_w, num_fields as u32)?;
+    write_u32(&mut doc_w, presence_bytes.len() as u32)?;
+    write_u64(&mut doc_w, blob_len)?;
+    write_u64(&mut doc_w, footer_start)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use serde_json::json;
+    use tachyon_core::{FieldSchema, FieldType, ParsedDocument};
+
+    use crate::fuzzy::FuzzyMatcher;
+    use crate::memtable::MemTable;
+    use crate::source::IndexSource;
+
+    use super::super::SegmentFilePaths;
+    use super::*;
+
+    fn schema() -> CollectionSchema {
+        CollectionSchema::new(
+            "products",
+            vec![
+                FieldSchema::new("title", FieldType::Text).required(),
+                FieldSchema::new("tags", FieldType::Text),
+                FieldSchema::new("brand", FieldType::Keyword).with_facet(true),
+                FieldSchema::new("price", FieldType::Int).with_filter(true).with_sort(true),
+            ],
+        )
+    }
+
+    fn doc(id: &str, title: &str, tags: &[&str], brand: &str, price: i64) -> ParsedDocument {
+        ParsedDocument::parse(
+            json!({ "id": id, "title": title, "tags": tags, "brand": brand, "price": price }),
+            &schema(),
+        )
+        .unwrap()
+    }
+
+    /// Encode `m` and write it out as a real segment under `dir`, returning
+    /// a reader over it — everything downstream needs mmap'd files, not an
+    /// in-memory blob.
+    fn write_segment(
+        dir: &Path,
+        id: u64,
+        m: &MemTable,
+        schema: &CollectionSchema,
+    ) -> SegmentReader {
+        let encoded = codec::encode(m, schema).unwrap();
+        let paths = SegmentFilePaths {
+            terms: dir.join(format!("{id}.terms")),
+            ids: dir.join(format!("{id}.ids")),
+            post: dir.join(format!("{id}.post")),
+            col: dir.join(format!("{id}.col")),
+            doc: dir.join(format!("{id}.doc")),
+        };
+        std::fs::write(&paths.terms, &encoded.terms).unwrap();
+        std::fs::write(&paths.ids, &encoded.ids).unwrap();
+        std::fs::write(&paths.post, &encoded.post).unwrap();
+        std::fs::write(&paths.col, &encoded.col).unwrap();
+        std::fs::write(&paths.doc, &encoded.doc).unwrap();
+        SegmentReader::open(&paths, schema).unwrap()
+    }
+
+    /// Stream a merge of `inputs` into a real segment under `dir` and open a
+    /// reader over the result.
+    fn write_merged(
+        dir: &Path,
+        id: u64,
+        inputs: &[MergeInput],
+        schema: &CollectionSchema,
+        base: DocId,
+    ) -> (SegmentReader, MergeStats) {
+        let paths = SegmentFilePaths {
+            terms: dir.join(format!("{id}.terms")),
+            ids: dir.join(format!("{id}.ids")),
+            post: dir.join(format!("{id}.post")),
+            col: dir.join(format!("{id}.col")),
+            doc: dir.join(format!("{id}.doc")),
+        };
+        let terms_f = std::fs::File::create(&paths.terms).unwrap();
+        let ids_f = std::fs::File::create(&paths.ids).unwrap();
+        let post_f = std::fs::File::create(&paths.post).unwrap();
+        let col_f = std::fs::File::create(&paths.col).unwrap();
+        let doc_f = std::fs::File::create(&paths.doc).unwrap();
+        let stats =
+            merge_segments(inputs, schema, base, terms_f, ids_f, post_f, col_f, doc_f).unwrap();
+        (SegmentReader::open(&paths, schema).unwrap(), stats)
+    }
+
+    /// The independent, obviously-correct reference a streamed merge is
+    /// checked against: re-parse and re-tokenize every surviving document —
+    /// exactly what the pre-v4 merge used to do in production — from a fresh
+    /// `base`, in the same order `merge_segments` itself visits them (input
+    /// order, then ascending doc id within an input). If the streaming
+    /// merge and this oracle ever disagree, the streaming merge is wrong;
+    /// this is deliberately the slow, boring path with nothing to double-
+    /// check it against but "read the test fixtures".
+    fn oracle(
+        readers: &[&SegmentReader],
+        lives: &[RoaringBitmap],
+        schema: &CollectionSchema,
+        base: DocId,
+    ) -> MemTable {
+        let mut m = MemTable::new(base, schema);
+        for (reader, live) in readers.iter().zip(lives) {
+            for old_id in live.iter() {
+                let source = reader.get(old_id).expect("live doc must have a source");
+                m.insert(ParsedDocument::parse(source, schema).unwrap());
+            }
+        }
+        m
+    }
+
+    /// Every `IndexSource` answer a query could ask for, compared between
+    /// two sources over the same doc id range and vocabulary — the same
+    /// shape `segment::reader`'s own memtable-vs-segment test uses, reused
+    /// here to compare a streamed merge against its oracle.
+    fn assert_index_sources_agree(
+        a: &dyn IndexSource,
+        b: &dyn IndexSource,
+        schema: &CollectionSchema,
+        vocab: &[&str],
+    ) {
+        assert_eq!(a.min_doc_id(), b.min_doc_id());
+        assert_eq!(a.end_doc_id(), b.end_doc_id());
+
+        for doc_id in a.min_doc_id()..a.end_doc_id() {
+            assert_eq!(a.is_live(doc_id), b.is_live(doc_id), "doc {doc_id} liveness");
+            for field in 0..schema.fields.len() as FieldId {
+                assert_eq!(
+                    a.value(doc_id, field).as_deref(),
+                    b.value(doc_id, field).as_deref(),
+                    "doc {doc_id} field {field} value"
+                );
+                assert_eq!(
+                    a.field_len(doc_id, field),
+                    b.field_len(doc_id, field),
+                    "doc {doc_id} field {field} length"
+                );
+            }
+        }
+
+        fn drain(
+            source: &dyn IndexSource,
+            term: &str,
+            field: FieldId,
+        ) -> Option<Vec<(u32, Vec<u32>)>> {
+            let mut cursor = source.posting_cursor(term, field)?;
+            let mut out = Vec::new();
+            while let Some(doc_id) = cursor.doc_id() {
+                out.push((doc_id, cursor.positions()));
+                cursor.advance();
+            }
+            Some(out)
+        }
+
+        for &term in vocab {
+            for field in 0..schema.fields.len() as FieldId {
+                assert_eq!(
+                    drain(a, term, field),
+                    drain(b, term, field),
+                    "term {term:?} field {field}"
+                );
+                assert_eq!(
+                    a.doc_freq(term, field),
+                    b.doc_freq(term, field),
+                    "term {term:?} field {field} doc_freq"
+                );
+                assert_eq!(
+                    a.live_doc_freq(term, field, &RoaringBitmap::new()),
+                    b.live_doc_freq(term, field, &RoaringBitmap::new()),
+                    "term {term:?} field {field} live_doc_freq"
+                );
+            }
+        }
+
+        for prefix in ["", "a", "b", "m", "z"] {
+            let mut a_terms = Vec::new();
+            a.collect_terms_with_prefix(prefix, 1000, &mut a_terms);
+            let mut b_terms = Vec::new();
+            b.collect_terms_with_prefix(prefix, 1000, &mut b_terms);
+            a_terms.sort();
+            b_terms.sort();
+            assert_eq!(a_terms, b_terms, "prefix {prefix:?}");
+        }
+
+        for &term in vocab {
+            let mut a_fuzzy = Vec::new();
+            a.collect_fuzzy_terms(&mut FuzzyMatcher::new(term, 2), &mut a_fuzzy);
+            let mut b_fuzzy = Vec::new();
+            b.collect_fuzzy_terms(&mut FuzzyMatcher::new(term, 2), &mut b_fuzzy);
+            a_fuzzy.sort();
+            b_fuzzy.sort();
+            assert_eq!(a_fuzzy, b_fuzzy, "fuzzy around {term:?}");
+        }
+
+        for field in 0..schema.fields.len() as FieldId {
+            match (a.numeric_column(field), b.numeric_column(field)) {
+                (Some(ac), Some(bc)) => {
+                    assert_eq!(
+                        ac.range(None, None).len(),
+                        bc.range(None, None).len(),
+                        "field {field}"
+                    );
+                }
+                (None, None) => {}
+                other => panic!(
+                    "field {field}: numeric column presence disagrees: {other:?}",
+                    other = (other.0.is_some(), other.1.is_some())
+                ),
+            }
+            match (a.keyword_column(field), b.keyword_column(field)) {
+                (Some(ac), Some(bc)) => {
+                    assert_eq!(ac.num_values(), bc.num_values(), "field {field}");
+                }
+                (None, None) => {}
+                other => panic!(
+                    "field {field}: keyword column presence disagrees: {other:?}",
+                    other = (other.0.is_some(), other.1.is_some())
+                ),
+            }
+        }
+    }
+
+    fn full_presence(reader: &SegmentReader) -> RoaringBitmap {
+        reader.presence().clone()
+    }
+
+    #[test]
+    fn merging_two_segments_matches_the_rebuild_oracle_byte_for_byte() {
+        let schema = schema();
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut m0 = MemTable::new(0, &schema);
+        m0.insert(doc("1", "wireless mouse", &["red", "blue"], "Logitech", 2999));
+        m0.insert(doc("2", "mouse pad", &["blue"], "Razer", 1999));
+        let r0 = write_segment(dir.path(), 1, &m0, &schema);
+
+        let mut m1 = MemTable::new(2, &schema);
+        m1.insert(doc("3", "mechanical keyboard", &["rgb"], "Corsair", 8999));
+        m1.insert(doc("4", "wireless keyboard", &["compact"], "Logitech", 5999));
+        let r1 = write_segment(dir.path(), 2, &m1, &schema);
+
+        let lives = [full_presence(&r0), full_presence(&r1)];
+        let inputs = vec![
+            MergeInput { reader: &r0, live: lives[0].clone() },
+            MergeInput { reader: &r1, live: lives[1].clone() },
+        ];
+        let (merged, stats) = write_merged(dir.path(), 99, &inputs, &schema, 0);
+        assert_eq!(stats.doc_count, 4);
+
+        let oracle_mem = oracle(&[&r0, &r1], &lives, &schema, 0);
+        let oracle_seg = write_segment(dir.path(), 100, &oracle_mem, &schema);
+
+        assert_index_sources_agree(
+            &merged,
+            &oracle_seg,
+            &schema,
+            &[
+                "wireless",
+                "mouse",
+                "keyboard",
+                "mechanical",
+                "pad",
+                "red",
+                "blue",
+                "rgb",
+                "compact",
+            ],
+        );
+
+        // The strongest possible check: with the flush encoder's output
+        // deterministic (see `codec`'s own determinism test) and the merge
+        // visiting documents in exactly the order the oracle does, the two
+        // segments' bytes should be indistinguishable, not just semantically
+        // equivalent.
+        for ext in ["terms", "ids", "post", "col", "doc"] {
+            let merged_path = dir.path().join(format!("99.{ext}"));
+            let oracle_path = dir.path().join(format!("100.{ext}"));
+            assert_eq!(
+                std::fs::read(&merged_path).unwrap(),
+                std::fs::read(&oracle_path).unwrap(),
+                "{ext} bytes must match the oracle exactly"
+            );
+        }
+    }
+
+    #[test]
+    fn tombstoned_documents_do_not_survive_a_merge() {
+        let schema = schema();
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut m0 = MemTable::new(0, &schema);
+        let keep = m0.insert(doc("1", "wireless mouse", &[], "Logitech", 2999));
+        let drop = m0.insert(doc("2", "mouse pad", &[], "Razer", 1999));
+        let r0 = write_segment(dir.path(), 1, &m0, &schema);
+
+        // `drop` is still present in the segment (it was live when flushed)
+        // but is tombstoned at the collection level — the caller's job,
+        // mirrored here, is to exclude it from `live` before merging.
+        let mut live = full_presence(&r0);
+        live.remove(drop);
+        assert!(live.contains(keep));
+
+        let inputs = vec![MergeInput { reader: &r0, live: live.clone() }];
+        let (merged, stats) = write_merged(dir.path(), 2, &inputs, &schema, 0);
+        assert_eq!(stats.doc_count, 1);
+        assert!(merged.is_live(0));
+        assert!(!merged.is_live(1));
+        assert_eq!(merged.get(0).unwrap()["id"], json!("1"));
+
+        // The dropped document's term must not survive either.
+        assert!(merged.posting_cursor("pad", 0).is_none());
+        assert!(merged.posting_cursor("mouse", 0).is_some());
+    }
+
+    #[test]
+    fn a_term_alive_in_only_one_input_is_not_corrupted_by_the_union() {
+        let schema = schema();
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut m0 = MemTable::new(0, &schema);
+        m0.insert(doc("1", "keyboard", &[], "Corsair", 100));
+        let r0 = write_segment(dir.path(), 1, &m0, &schema);
+
+        let mut m1 = MemTable::new(1, &schema);
+        m1.insert(doc("2", "mouse", &[], "Razer", 200));
+        let r1 = write_segment(dir.path(), 2, &m1, &schema);
+
+        let lives = [full_presence(&r0), full_presence(&r1)];
+        let inputs = vec![
+            MergeInput { reader: &r0, live: lives[0].clone() },
+            MergeInput { reader: &r1, live: lives[1].clone() },
+        ];
+        let (merged, _) = write_merged(dir.path(), 3, &inputs, &schema, 0);
+
+        let mut kb = merged.posting_cursor("keyboard", 0).unwrap();
+        assert_eq!(kb.doc_id(), Some(0));
+        kb.advance();
+        assert_eq!(kb.doc_id(), None, "keyboard only ever occurred in input 0's one document");
+
+        let mouse = merged.posting_cursor("mouse", 0).unwrap();
+        assert_eq!(mouse.doc_id(), Some(1));
+    }
+
+    #[test]
+    fn a_keyword_value_alive_in_only_one_input_gets_the_right_bitmap() {
+        let schema = schema();
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut m0 = MemTable::new(0, &schema);
+        m0.insert(doc("1", "a", &[], "OnlyInZero", 1));
+        m0.insert(doc("2", "b", &[], "Shared", 2));
+        let r0 = write_segment(dir.path(), 1, &m0, &schema);
+
+        let mut m1 = MemTable::new(2, &schema);
+        m1.insert(doc("3", "c", &[], "Shared", 3));
+        m1.insert(doc("4", "d", &[], "OnlyInOne", 4));
+        let r1 = write_segment(dir.path(), 2, &m1, &schema);
+
+        let lives = [full_presence(&r0), full_presence(&r1)];
+        let inputs = vec![
+            MergeInput { reader: &r0, live: lives[0].clone() },
+            MergeInput { reader: &r1, live: lives[1].clone() },
+        ];
+        let (merged, _) = write_merged(dir.path(), 3, &inputs, &schema, 0);
+
+        let brand = merged.keyword_column(2).unwrap();
+        assert_eq!(brand.equals("OnlyInZero").iter().collect::<Vec<_>>(), vec![0]);
+        assert_eq!(brand.equals("OnlyInOne").iter().collect::<Vec<_>>(), vec![3]);
+        let mut shared = brand.equals("Shared").iter().collect::<Vec<_>>();
+        shared.sort();
+        assert_eq!(shared, vec![1, 2]);
+        assert_eq!(
+            brand.num_values(),
+            3,
+            "OnlyInZero, Shared, OnlyInOne — Shared is not distinct twice"
+        );
+    }
+
+    #[test]
+    fn a_completely_dead_input_contributes_nothing_but_does_not_break_the_merge() {
+        let schema = schema();
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut m0 = MemTable::new(0, &schema);
+        let a = m0.insert(doc("1", "will be deleted", &[], "X", 1));
+        let b = m0.insert(doc("2", "also deleted", &[], "Y", 2));
+        m0.remove(a);
+        m0.remove(b);
+        let r0 = write_segment(dir.path(), 1, &m0, &schema);
+        assert!(
+            full_presence(&r0).is_empty(),
+            "both docs were deleted before this segment ever flushed"
+        );
+
+        let mut m1 = MemTable::new(2, &schema);
+        m1.insert(doc("3", "survives", &[], "Z", 3));
+        let r1 = write_segment(dir.path(), 2, &m1, &schema);
+
+        let inputs = vec![
+            MergeInput { reader: &r0, live: full_presence(&r0) },
+            MergeInput { reader: &r1, live: full_presence(&r1) },
+        ];
+        let (merged, stats) = write_merged(dir.path(), 3, &inputs, &schema, 0);
+        assert_eq!(stats.doc_count, 1);
+        assert_eq!(merged.min_doc_id(), 0);
+        assert!(merged.is_live(0));
+        assert_eq!(merged.get(0).unwrap()["id"], json!("3"));
+    }
+
+    #[test]
+    fn a_merge_output_can_itself_be_merged_again() {
+        // The merge output must be a fully ordinary segment, not one that
+        // only survives being *read*: feeding a first merge's output back in
+        // as an input to a second merge exercises that its own presence
+        // bitmap, term dictionary, and doc-store rows are all as valid as
+        // any freshly flushed segment's.
+        let schema = schema();
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut m0 = MemTable::new(0, &schema);
+        m0.insert(doc("1", "first", &[], "A", 1));
+        let r0 = write_segment(dir.path(), 1, &m0, &schema);
+        let mut m1 = MemTable::new(1, &schema);
+        m1.insert(doc("2", "second", &[], "B", 2));
+        let r1 = write_segment(dir.path(), 2, &m1, &schema);
+
+        let first_inputs = vec![
+            MergeInput { reader: &r0, live: full_presence(&r0) },
+            MergeInput { reader: &r1, live: full_presence(&r1) },
+        ];
+        let (first_merge, _) = write_merged(dir.path(), 3, &first_inputs, &schema, 0);
+
+        let mut m2 = MemTable::new(2, &schema);
+        m2.insert(doc("3", "third", &[], "C", 3));
+        let r2 = write_segment(dir.path(), 4, &m2, &schema);
+
+        let second_inputs = vec![
+            MergeInput { reader: &first_merge, live: full_presence(&first_merge) },
+            MergeInput { reader: &r2, live: full_presence(&r2) },
+        ];
+        let (second_merge, stats) = write_merged(dir.path(), 5, &second_inputs, &schema, 0);
+        assert_eq!(stats.doc_count, 3);
+        for (id, expected) in [(0, "1"), (1, "2"), (2, "3")] {
+            assert_eq!(second_merge.get(id).unwrap()["id"], json!(expected));
+        }
+    }
+
+    #[test]
+    fn a_fan_in_of_four_remaps_ids_densely_across_every_input() {
+        let schema = schema();
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut readers = Vec::new();
+        let mut base = 0;
+        for batch in 0..4 {
+            let mut m = MemTable::new(base, &schema);
+            for i in 0..3 {
+                m.insert(doc(&format!("{batch}-{i}"), "widget", &[], "Brand", i));
+            }
+            let r = write_segment(dir.path(), batch + 1, &m, &schema);
+            base += 3;
+            readers.push(r);
+        }
+
+        let lives: Vec<RoaringBitmap> = readers.iter().map(full_presence).collect();
+        let inputs: Vec<MergeInput> = readers
+            .iter()
+            .zip(&lives)
+            .map(|(r, l)| MergeInput { reader: r, live: l.clone() })
+            .collect();
+        let (merged, stats) = write_merged(dir.path(), 99, &inputs, &schema, 0);
+        assert_eq!(stats.doc_count, 12, "4 segments x 3 live docs each");
+        for id in 0..12 {
+            assert!(merged.is_live(id), "doc {id} must be dense and live");
+        }
+        assert!(!merged.is_live(12));
+
+        let widget = merged.posting_cursor("widget", 0).unwrap();
+        let mut cursor = widget;
+        let mut seen = Vec::new();
+        while let Some(id) = cursor.doc_id() {
+            seen.push(id);
+            cursor.advance();
+        }
+        assert_eq!(
+            seen,
+            (0..12).collect::<Vec<_>>(),
+            "every one of the 12 docs matches \"widget\""
+        );
+    }
+
+    #[test]
+    fn a_larger_randomized_merge_matches_the_oracle() {
+        let schema = schema();
+        let dir = tempfile::tempdir().unwrap();
+
+        let words = ["mouse", "keyboard", "monitor", "cable", "stand", "hub", "dock", "case"];
+        let brands = ["Logitech", "Razer", "Corsair", "Anker", "HyperX"];
+
+        let mut readers = Vec::new();
+        let mut lives = Vec::new();
+        let mut base = 0;
+        let mut counter = 0usize;
+        for seg in 0..3usize {
+            let mut m = MemTable::new(base, &schema);
+            let mut doc_ids = Vec::new();
+            for i in 0..40 {
+                let w1 = words[(seg * 7 + i * 3) % words.len()];
+                let w2 = words[(seg * 11 + i * 5 + 1) % words.len()];
+                let brand = brands[(seg + i) % brands.len()];
+                let title = format!("{w1} {w2}");
+                let id = m.insert(doc(&format!("{counter}"), &title, &[w1], brand, i as i64));
+                doc_ids.push(id);
+                counter += 1;
+            }
+            // Delete roughly a third, in a fixed but non-trivial pattern.
+            for (i, &id) in doc_ids.iter().enumerate() {
+                if i % 3 == 0 {
+                    m.remove(id);
+                }
+            }
+            let r = write_segment(dir.path(), seg as u64 + 1, &m, &schema);
+            let mut live = full_presence(&r);
+            // Also tombstone one more doc at the "collection" level, past
+            // what was already deleted before the flush.
+            if let Some(extra) = live.iter().nth(2) {
+                live.remove(extra);
+            }
+            base += 40;
+            lives.push(live);
+            readers.push(r);
+        }
+
+        let reader_refs: Vec<&SegmentReader> = readers.iter().collect();
+        let inputs: Vec<MergeInput> = reader_refs
+            .iter()
+            .zip(&lives)
+            .map(|(&r, l)| MergeInput { reader: r, live: l.clone() })
+            .collect();
+        let (merged, stats) = write_merged(dir.path(), 99, &inputs, &schema, 0);
+
+        let oracle_mem = oracle(&reader_refs, &lives, &schema, 0);
+        assert_eq!(stats.doc_count, oracle_mem.len());
+        let oracle_seg = write_segment(dir.path(), 100, &oracle_mem, &schema);
+
+        let mut vocab: Vec<&str> = words.to_vec();
+        vocab.extend(brands);
+        assert_index_sources_agree(&merged, &oracle_seg, &schema, &vocab);
+    }
+}
+
+/// Regression coverage for a real bug this rewrite shipped and caught before
+/// release: `decode_term_field_blocks` stopped skipping a non-matching
+/// field's payload bytes once block offsets became absolute (the skip
+/// looked redundant — the offsets no longer needed rebasing — but the
+/// *cursor* still needed to walk past those bytes to reach the next field's
+/// header). It went undetected by every hand-built fixture because none of
+/// them combined a term spanning multiple postings blocks with occurring in
+/// more than one field of the same document. These two modules exist
+/// specifically to keep exercising that combination.
+#[cfg(test)]
+mod block_boundary_tests {
+    use serde_json::json;
+    use tachyon_core::{FieldSchema, FieldType, ParsedDocument};
+
+    use crate::memtable::MemTable;
+    use crate::source::IndexSource;
+
+    use super::super::SegmentFilePaths;
+    use super::*;
+
+    #[test]
+    fn a_term_spanning_multiple_blocks_in_two_fields_survives_a_merge() {
+        let schema = CollectionSchema::new(
+            "products",
+            vec![
+                FieldSchema::new("title", FieldType::Text).required(),
+                FieldSchema::new("tags", FieldType::Text),
+            ],
+        );
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut readers = Vec::new();
+        let mut base = 0;
+        for seg in 0..2u32 {
+            let mut m = MemTable::new(base, &schema);
+            for i in 0..150 {
+                let doc = ParsedDocument::parse(
+                    json!({ "id": format!("{seg}-{i}"), "title": "widget", "tags": "widget" }),
+                    &schema,
+                )
+                .unwrap();
+                m.insert(doc);
+            }
+            let encoded = codec::encode(&m, &schema).unwrap();
+            let paths = SegmentFilePaths {
+                terms: dir.path().join(format!("{seg}.terms")),
+                ids: dir.path().join(format!("{seg}.ids")),
+                post: dir.path().join(format!("{seg}.post")),
+                col: dir.path().join(format!("{seg}.col")),
+                doc: dir.path().join(format!("{seg}.doc")),
+            };
+            std::fs::write(&paths.terms, &encoded.terms).unwrap();
+            std::fs::write(&paths.ids, &encoded.ids).unwrap();
+            std::fs::write(&paths.post, &encoded.post).unwrap();
+            std::fs::write(&paths.col, &encoded.col).unwrap();
+            std::fs::write(&paths.doc, &encoded.doc).unwrap();
+            readers.push(SegmentReader::open(&paths, &schema).unwrap());
+            base += 150;
+        }
+
+        let lives: Vec<RoaringBitmap> = readers.iter().map(|r| r.presence().clone()).collect();
+        let inputs: Vec<MergeInput> = readers
+            .iter()
+            .zip(&lives)
+            .map(|(r, l)| MergeInput { reader: r, live: l.clone() })
+            .collect();
+
+        let paths = SegmentFilePaths {
+            terms: dir.path().join("m.terms"),
+            ids: dir.path().join("m.ids"),
+            post: dir.path().join("m.post"),
+            col: dir.path().join("m.col"),
+            doc: dir.path().join("m.doc"),
+        };
+        let terms_f = std::fs::File::create(&paths.terms).unwrap();
+        let ids_f = std::fs::File::create(&paths.ids).unwrap();
+        let post_f = std::fs::File::create(&paths.post).unwrap();
+        let col_f = std::fs::File::create(&paths.col).unwrap();
+        let doc_f = std::fs::File::create(&paths.doc).unwrap();
+        let stats =
+            merge_segments(&inputs, &schema, 0, terms_f, ids_f, post_f, col_f, doc_f).unwrap();
+        assert_eq!(stats.doc_count, 300);
+
+        let merged = SegmentReader::open(&paths, &schema).unwrap();
+        let mut cursor = merged.posting_cursor("widget", 0).unwrap();
+        let mut count = 0;
+        while let Some(_id) = cursor.doc_id() {
+            count += 1;
+            cursor.advance();
+        }
+        assert_eq!(count, 300, "every one of the 300 docs must be found across block boundaries");
+    }
+}
+
+#[cfg(test)]
+mod realistic_corpus_tests {
+    use serde_json::json;
+    use tachyon_core::{FieldSchema, FieldType, ParsedDocument};
+
+    use crate::memtable::MemTable;
+    use crate::source::IndexSource;
+
+    use super::super::SegmentFilePaths;
+    use super::*;
+
+    pub(super) fn schema() -> CollectionSchema {
+        CollectionSchema::new(
+            "products",
+            vec![
+                FieldSchema::new("title", FieldType::Text).required(),
+                FieldSchema::new("description", FieldType::Text),
+                FieldSchema::new("brand", FieldType::Keyword).with_facet(true),
+                FieldSchema::new("category", FieldType::Keyword).with_facet(true),
+                FieldSchema::new("price", FieldType::Int).with_filter(true).with_sort(true),
+                FieldSchema::new("rating", FieldType::Float).with_filter(true).with_sort(true),
+            ],
+        )
+    }
+
+    const ADJ: &[&str] = &[
+        "wireless",
+        "wired",
+        "mechanical",
+        "ergonomic",
+        "silent",
+        "compact",
+        "portable",
+        "premium",
+        "rugged",
+        "slim",
+        "gaming",
+        "professional",
+        "vintage",
+        "modular",
+        "waterproof",
+    ];
+    const NOUN: &[&str] = &[
+        "mouse",
+        "keyboard",
+        "monitor",
+        "headset",
+        "webcam",
+        "microphone",
+        "speaker",
+        "hub",
+        "charger",
+        "cable",
+        "adapter",
+        "stand",
+        "dock",
+        "controller",
+        "tablet",
+    ];
+    const BRAND: &[&str] =
+        &["Logitech", "Razer", "Anker", "Corsair", "Keychron", "Belkin", "Elgato"];
+    const CATEGORY: &[&str] = &["peripherals", "audio", "power", "display", "accessories"];
+
+    pub(super) struct Rng(pub u64);
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x >> 12;
+            x ^= x << 25;
+            x ^= x >> 27;
+            self.0 = x;
+            x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+        }
+        fn below(&mut self, n: usize) -> usize {
+            (self.next() % n as u64) as usize
+        }
+        /// Biased towards the front, like `corpus::Rng::zipfish` — the real
+        /// generator's skew is what makes some words wildly more common than
+        /// others, producing terms whose postings span many more blocks than
+        /// a uniform distribution ever would.
+        fn zipfish(&mut self, n: usize) -> usize {
+            let a = self.below(n);
+            let b = self.below(n);
+            a.min(b)
+        }
+    }
+
+    pub(super) fn document(rng: &mut Rng, id: usize) -> ParsedDocument {
+        let adjective = ADJ[rng.zipfish(ADJ.len())];
+        let noun = NOUN[rng.zipfish(NOUN.len())];
+        let title = format!("{adjective} {noun}");
+        let description = format!("A {adjective} {noun} built for everyday use.");
+        ParsedDocument::parse(
+            json!({
+                "id": id.to_string(),
+                "title": title,
+                "description": description,
+                "brand": BRAND[rng.below(BRAND.len())],
+                "category": CATEGORY[rng.below(CATEGORY.len())],
+                "price": (rng.below(50_000) + 500) as i64,
+                "rating": (rng.below(50) as f64) / 10.0,
+            }),
+            &schema(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn merging_two_realistic_250_doc_segments_matches_every_term_against_the_source() {
+        let schema = schema();
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut readers = Vec::new();
+        let mut base = 0;
+        let mut rng = Rng(42);
+        for seg in 0..2u64 {
+            let mut m = MemTable::new(base, &schema);
+            for i in 0..250 {
+                m.insert(document(&mut rng, (seg * 1000 + i) as usize));
+            }
+            let encoded = codec::encode(&m, &schema).unwrap();
+            let paths = SegmentFilePaths {
+                terms: dir.path().join(format!("{seg}.terms")),
+                ids: dir.path().join(format!("{seg}.ids")),
+                post: dir.path().join(format!("{seg}.post")),
+                col: dir.path().join(format!("{seg}.col")),
+                doc: dir.path().join(format!("{seg}.doc")),
+            };
+            std::fs::write(&paths.terms, &encoded.terms).unwrap();
+            std::fs::write(&paths.ids, &encoded.ids).unwrap();
+            std::fs::write(&paths.post, &encoded.post).unwrap();
+            std::fs::write(&paths.col, &encoded.col).unwrap();
+            std::fs::write(&paths.doc, &encoded.doc).unwrap();
+            readers.push(SegmentReader::open(&paths, &schema).unwrap());
+            base += 250;
+        }
+
+        let lives: Vec<RoaringBitmap> = readers.iter().map(|r| r.presence().clone()).collect();
+        let inputs: Vec<MergeInput> = readers
+            .iter()
+            .zip(&lives)
+            .map(|(r, l)| MergeInput { reader: r, live: l.clone() })
+            .collect();
+
+        let paths = SegmentFilePaths {
+            terms: dir.path().join("m.terms"),
+            ids: dir.path().join("m.ids"),
+            post: dir.path().join("m.post"),
+            col: dir.path().join("m.col"),
+            doc: dir.path().join("m.doc"),
+        };
+        let terms_f = std::fs::File::create(&paths.terms).unwrap();
+        let ids_f = std::fs::File::create(&paths.ids).unwrap();
+        let post_f = std::fs::File::create(&paths.post).unwrap();
+        let col_f = std::fs::File::create(&paths.col).unwrap();
+        let doc_f = std::fs::File::create(&paths.doc).unwrap();
+        merge_segments(&inputs, &schema, 0, terms_f, ids_f, post_f, col_f, doc_f).unwrap();
+
+        let merged = SegmentReader::open(&paths, &schema).unwrap();
+        // Every distinct word in the vocabulary, in both text fields: with
+        // 500 documents drawn from a 15-word Zipf-biased distribution, the
+        // most common words comfortably span several 128-doc posting
+        // blocks, and every word occurs in both `title` and `description` —
+        // exactly the combination this module's doc comment describes.
+        for &term in ADJ.iter().chain(NOUN) {
+            for field in 0..2u16 {
+                let Some(mut cursor) = merged.posting_cursor(term, field) else { continue };
+                let mut decoded = 0;
+                while let Some(doc_id) = cursor.doc_id() {
+                    let source = merged.get(doc_id).expect("a live doc must have a source");
+                    let text =
+                        source[if field == 0 { "title" } else { "description" }].as_str().unwrap();
+                    assert!(
+                        text.contains(term),
+                        "doc {doc_id} field {field} matched {term:?} but its text is {text:?}"
+                    );
+                    let _ = cursor.positions();
+                    cursor.advance();
+                    decoded += 1;
+                }
+                assert!(decoded > 0);
+            }
+        }
+    }
+}

--- a/crates/tachyon-index/src/segment/mod.rs
+++ b/crates/tachyon-index/src/segment/mod.rs
@@ -12,7 +12,9 @@
 mod codec;
 mod cursor;
 mod format;
+mod merge;
 mod reader;
 
-pub use codec::{encode, EncodedSegment};
+pub use codec::{encode, encode_streaming, EncodedSegment};
+pub use merge::{merge_segments, MergeInput, MergeStats};
 pub use reader::{SegmentFilePaths, SegmentReader};

--- a/crates/tachyon-index/src/segment/reader.rs
+++ b/crates/tachyon-index/src/segment/reader.rs
@@ -142,6 +142,16 @@ impl SegmentReader {
         self.terms_get(&self.ids, id)
     }
 
+    /// This segment's own presence bitmap — every doc id it holds a live
+    /// document for, with no holes for anything that was deleted before
+    /// this segment was ever flushed. `tachyon-engine`'s merge path
+    /// intersects this against the collection's own tombstones to get the
+    /// set of ids that should survive a merge; everywhere else, `is_live`
+    /// (one doc id at a time, via [`IndexSource`]) is the right entry point.
+    pub fn presence(&self) -> &RoaringBitmap {
+        &self.doc_header.presence
+    }
+
     fn terms_get(&self, map: &fst::Map<Mmap>, key: &str) -> Option<DocId> {
         map.get(key).map(|v| v as DocId)
     }
@@ -160,6 +170,46 @@ impl SegmentReader {
                 None
             }
         }
+    }
+
+    // --- raw accessors for `super::merge` -----------------------------
+    //
+    // A merge reads several segments' raw bytes directly (term FSTs for a
+    // union walk, block directories for a reblock-and-copy, doc-store
+    // sections for a verbatim byte copy) rather than going through
+    // `IndexSource`'s per-query decode surface, so it needs the mapped bytes
+    // and headers themselves, not just what a search ever asks for.
+
+    pub(crate) fn terms_map(&self) -> &fst::Map<Mmap> {
+        &self.terms
+    }
+
+    pub(crate) fn ids_map(&self) -> &fst::Map<Mmap> {
+        &self.ids
+    }
+
+    pub(crate) fn post_bytes(&self) -> &[u8] {
+        &self.post
+    }
+
+    pub(crate) fn post_header(&self) -> &PostHeader {
+        &self.post_header
+    }
+
+    pub(crate) fn col_bytes(&self) -> &[u8] {
+        &self.col
+    }
+
+    pub(crate) fn col_header(&self) -> &ColHeader {
+        &self.col_header
+    }
+
+    pub(crate) fn doc_bytes(&self) -> &[u8] {
+        &self.doc
+    }
+
+    pub(crate) fn doc_header(&self) -> &DocHeader {
+        &self.doc_header
     }
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,12 +112,22 @@ A flush turns a memtable into five immutable files — `<id>.terms`, `<id>.ids`,
 structure rather than one shared blob, so postings, columns, and the document
 store can each use whatever layout suits them without agreeing on a common
 framing. `.terms` and `.ids` are `fst::Map`s (term → dense id, and user id →
-doc id); `.post`, `.col`, and `.doc` each carry a small eager header — an
-offset table, essentially — followed by the data it points into.
+doc id), streamed directly through `fst::MapBuilder` as terms/ids are
+visited in sorted order. `.post`, `.col`, and `.doc` each open with a 12-byte
+header (a magic string and the format version) and close with a small
+footer — an offset table, essentially — whose own position is named by the
+file's last 8 bytes. The footer sits at the *end* rather than the front on
+purpose: a writer can then stream payload bytes forward as it produces them
+and only needs the directory's contents, never its file position, once
+everything before it is already written — which is what lets both a flush
+and a merge (see "Merges" below) write a segment in bounded memory, without
+ever holding the whole thing assembled first. Nothing about *reading* a
+segment cares where the footer sits; mmap makes every byte in the file
+equally cheap to reach regardless.
 
 Every file is mmap'd, and every read decodes only what it was asked for:
 
-- **`.post`**: the header holds per-field corpus stats and a byte offset per
+- **`.post`**: the footer holds per-field corpus stats and a byte offset per
   term. A query resolves a term through `.terms`' FST to a dense id, then
   decodes just that one term's block — nothing else in the file is touched.
   `doc_freq`/`live_doc_freq` go further still: they only ever need a document
@@ -125,7 +135,7 @@ Every file is mmap'd, and every read decodes only what it was asked for:
   position arrays instead of decoding and allocating them — the difference
   matters because autocomplete calls both across every candidate term and
   every source.
-- **`.col`**: the header is a small per-field directory (tag, offset,
+- **`.col`**: the footer is a small per-field directory (tag, offset,
   length). A query decodes one field's column — reusing
   `NumericColumn`/`KeywordColumn` verbatim via `from_sorted`/`from_parts` —
   never the whole file.
@@ -265,29 +275,34 @@ down over several flushes rather than in one large pause.
 **A merge renumbers documents, it does not preserve their ids.** A segment's
 doc-id range is fixed for its life (see "Segments" above), so folding two
 already-committed segments together while keeping their original ids would
-mean merging two already-*encoded* structures — a from-scratch k-way merge of
-sorted term dictionaries and postings. Renumbering sidesteps that entirely:
-a merge fetches each live, non-tombstoned document's source through
-`SegmentReader::get`, runs it back through `ParsedDocument::parse` — the
-exact validation and tokenization a fresh insert already does — and feeds
-the result into a scratch `MemTable`, then calls the ordinary `encode` on
-it. The entire insert/encode pipeline is reused unchanged; the only new
-code is picking victims and updating the commit state. Retired ids are
-simply never claimed again, and any tombstones for them are pruned from
-`state.json`'s `deleted` list as part of the merge's own commit, the same
-way a flush's own commit is the point of no return.
+mean merging two already-*encoded* structures anyway, just without the
+freedom to renumber — old ids would have to be preserved gap-for-gap. Since
+renumbering was going to happen either way, `tachyon_index::merge_segments`
+(`crates/tachyon-index/src/segment/merge.rs`) does the direct merge instead:
+a streaming k-way union of the victims' term dictionaries (`fst::map::OpBuilder`)
+and postings, columns, and doc-store rows, with every surviving id remapped
+as it goes (see the module's own doc comment for the exact rank-based
+remapping). Nothing here re-parses a document's source or re-tokenizes its
+text — that work already happened once, when each victim was first flushed.
+A `Null`/`Bool`/`Int`/`Float` value slot is copied as 13 raw bytes with no
+decode at all; a `Str`/`Array` slot's blob bytes and a document's stored
+source JSON are copied verbatim, with only offsets rebased to the new
+file's positions. Only postings are actually decoded, and only because
+block boundaries genuinely shift once dead documents drop out and ids
+change. Retired ids are simply never claimed again, and any tombstones for
+them are pruned from `state.json`'s `deleted` list as part of the merge's
+own commit, the same way a flush's own commit is the point of no return.
 
-The cost of that reuse is a **transient memory spike while a merge is in
-flight**: rebuilding `merge_fan_in` segments' worth of live documents into a
-scratch memtable before encoding it means the merge briefly holds all of
-them decoded at once, proportional to `merge_fan_in × segment size` rather
-than to the corpus as a whole. Measured directly: peak RSS during a 1M-doc
-run with default settings was ~1.5 GiB captured mid-merge, but memory back
-at rest immediately after indexing finished (no merge in flight, no queries
-yet run) was ~49 MiB. It's a real, momentary cost worth accounting for when
-sizing `merge_fan_in` on a memory-constrained deployment — smaller values
-trade a bigger memory ceiling for more frequent, cheaper merges — but it is
-not sustained.
+Memory stays bounded by what one term-field's postings, one field's column,
+or one document's blob bytes need — never by corpus size or by
+`merge_fan_in × segment size`. Measured directly on a 1M-document
+collection (four 250k-document segments, `merge_fan_in=4`): each merge's own
+RSS delta averaged **~93 MiB**, peaking at **~110 MiB**, and a run's overall
+indexing peak RSS (four flushes plus the merges they triggered) fell from
+999 MiB to **646 MiB** compared to the pre-streaming merge — a genuine,
+sustained reduction, not just a shorter spike. `--merge-fan-in` still trades
+frequency against average merge cost the same way it always did; it no
+longer trades against a memory ceiling that scaled with the merge itself.
 
 ## Score-bound pruning
 
@@ -313,7 +328,7 @@ first place — see below for what does.
 Classical block-max WAND skips documents entirely, jumping ahead in sorted
 posting lists using per-block score bounds — incompatible with the exact
 counts the mechanism above preserves. This is now built as a genuinely
-separate, composed layer: `.post`'s v3 format groups a term's postings into
+separate, composed layer: `.post`'s format groups a term's postings into
 fixed 128-document blocks, each carrying its own max doc id, max term
 frequency, and byte offset, so a query can skip — or jump straight past — a
 whole block without decoding a single posting inside it. A lazy
@@ -353,10 +368,15 @@ bound check ever runs.
 
 ## What is not built yet
 
-**Streaming merges.** A merge currently rebuilds its input through a scratch
-memtable rather than merging the already-encoded structures directly, which
-is what causes the transient memory spike above. A direct k-way merge of
-sorted term dictionaries, columns, and doc stores across segments would
-avoid materializing anything beyond what's being written — real, novel code
-this workspace doesn't have yet, deferred until the spike above is shown to
-matter in practice.
+**Off-lock merging.** A merge still runs synchronously under the same
+write-lock hold as the flush that triggered it, so every search stalls for
+its duration — shrunk a great deal by the streaming rewrite above (no more
+re-parsing or re-tokenizing every merged document, no more materializing
+the whole merge in memory before writing it), but not eliminated. Segments
+are immutable and a merge only ever reads its victims, so in principle the
+bulk of a merge's work could run entirely outside the lock, taking it only
+for the final state swap — the real complication is a delete landing on a
+victim while its merge is still in flight, which has to be re-checked
+against the collection's tombstones and remapped into the new id space at
+swap time rather than silently resurrected. Deferred until the streaming
+merge's own remaining stall is shown to matter in practice.


### PR DESCRIPTION
.post/.col/.doc move their directory from a front-loaded header to a footer at EOF, so a writer can stream payload bytes forward and only needs the directory's contents, not its file position, once everything before it is written. .terms/.ids now stream straight through fst::MapBuilder instead of building in memory. Widened offset fields that silently truncated past 4 GiB.

Segment merge no longer rebuilds a MemTable from re-parsed, re-tokenized documents: tachyon_index::merge_segments streams a k-way merge of the victims' already-encoded term dictionaries, postings, columns, and doc stores directly, with only postings actually decoded (block boundaries shift once dead documents drop out) and everything else copied verbatim with offsets rebased.

Peak RSS at 5M documents falls from 5.2 GiB to 1.5 GiB, steady RSS from 3.4 GiB to 895 MiB, with indexing throughput and search latency unchanged. Flush-under-load worst-case concurrent-search stall drops from 3.7s to 1.9s at 1M documents.

Adds 8 correctness tests for the merge path, including a byte-for-byte oracle check and a realistic-corpus regression test that caught a real bug pre-release: decode_term_field_blocks stopped skipping a non-matching field's payload bytes once block offsets became absolute, corrupting reads for any term spanning multiple posting blocks in more than one field. tachyon-bench gains --merge-trigger-segments/ --merge-fan-in flags and a --merge-scenario for isolating per-merge wall time and RSS delta from indexing and query traffic.

README and architecture.md updated: the known-limitations banner about merge holding everything in memory is gone: the entry describes what's still true (merge holds the write lock, at greatly reduced cost) and "streaming merges" is removed from architecture.md's not-built-yet list.