### PR TITLE
Add missing labeler config for label.yml workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,13 @@
+rust:
+  - crates/**
+
+docs:
+  - docs/**
+  - "**/*.md"
+
+ci:
+  - .github/**
+
+docker:
+  - Dockerfile
+  - .dockerignore


### PR DESCRIPTION
actions/labeler@v4 requires .github/labeler.yml to map paths to labels; without it the Labeler workflow fails on every PR.